### PR TITLE
fixed install issue for postgres and region controller on same host

### DIFF
--- a/roles/maas_postgres_primary/tasks/main.yaml
+++ b/roles/maas_postgres_primary/tasks/main.yaml
@@ -13,3 +13,4 @@
   ansible.builtin.include_role:
     name: maas_firewall
     tasks_from: setup_firewall_rules
+  when: ('maas_region_controller' not in group_names)


### PR DESCRIPTION
This is meant to be a quick fix for the issue https://github.com/maas/maas-ansible-playbook/issues/37#issue-1430234247 

The 'add MAAS apt repository' task doesn't seem to execute successfully when postgres and region controller are placed on the same host, caused by firewall rules. This fix postpones the firewall setup until the end of install of both roles

