### PR TITLE
Issue database migration

### DIFF
--- a/group_vars/maas_proxy
+++ b/group_vars/maas_proxy
@@ -10,6 +10,7 @@ maas_proxy_postgres_upstreams: []
 maas_proxy_state: "install"
 
 maas_open_tcp_ports: 
+- "{{ 5432 if 'maas_postgres' in group_names}}"
 - "{{ maas_proxy_port }}"
 - "{{ maas_proxy_postgres_port}}"
 

--- a/group_vars/maas_proxy
+++ b/group_vars/maas_proxy
@@ -10,7 +10,7 @@ maas_proxy_postgres_upstreams: []
 maas_proxy_state: "install"
 
 maas_open_tcp_ports:
-- "{{ 5432 if 'maas_postgres' in group_names }}" 
+- "{{ 5432 if 'maas_postgres' in group_names else (false) }}" 
 - "{{ maas_proxy_port }}"
 - "{{ maas_proxy_postgres_port}}"
 

--- a/group_vars/maas_proxy
+++ b/group_vars/maas_proxy
@@ -9,8 +9,8 @@ maas_proxy_postgres_port: "{{ 5243 if 'maas_postgres' not in group_names else 50
 maas_proxy_postgres_upstreams: []
 maas_proxy_state: "install"
 
-maas_open_tcp_ports: 
-- "{{ 5432 if 'maas_postgres' in group_names}}"
+maas_open_tcp_ports:
+- "{{ 5432 if 'maas_postgres' in group_names }}" 
 - "{{ maas_proxy_port }}"
 - "{{ maas_proxy_postgres_port}}"
 

--- a/group_vars/maas_region_controller
+++ b/group_vars/maas_region_controller
@@ -2,13 +2,16 @@ maas_package_name: "{{ 'maas' if (not maas_install_deb|bool) else 'maas-region-a
 
 # MAAS installation setup
 enable_tls: false               # If an operator wishes to enable TLS
-install_metrics: false           # install metrics for the MAAS
 
 # administrator account details
 admin_username: "admin"
 admin_password: "admin"
 admin_email: "admin@email.com"
 admin_id: "admin"
+
+maas_proxy_port: "{{ 5240 if 'maas_region_controller' not in group_names else 5050 }}"
+maas_proxy_postgres_port: "{{ 5243 if 'maas_postgres' not in group_names else 5051 }}"
+
 
 maas_open_tcp_ports: 
 - 53 			# dns
@@ -20,6 +23,8 @@ maas_open_tcp_ports:
 - 5432 			# postgres
 - 5443 			# MAAS https port
 - 8000
+- "{{ maas_proxy_port if 'maas_proxy' in group_names }}"
+- "{{ maas_proxy_postgres_port if 'maas_proxy' in group_names }}"
 
 maas_open_udp_ports:
 - 53 			# dns

--- a/group_vars/maas_region_controller
+++ b/group_vars/maas_region_controller
@@ -23,8 +23,8 @@ maas_open_tcp_ports:
 - 5432 			# postgres
 - 5443 			# MAAS https port
 - 8000
-- "{{ maas_proxy_port if 'maas_proxy' in group_names }}"
-- "{{ maas_proxy_postgres_port if 'maas_proxy' in group_names }}"
+- "{{ maas_proxy_port if 'maas_proxy' in group_names else (false) }}"
+- "{{ maas_proxy_postgres_port if 'maas_proxy' in group_names else (false) }}"
 
 maas_open_udp_ports:
 - 53 			# dns

--- a/roles/maas_firewall/tasks/setup_firewall_rules.yaml
+++ b/roles/maas_firewall/tasks/setup_firewall_rules.yaml
@@ -44,10 +44,6 @@
     chain: FORWARD
     policy: DROP
 
-- name: Check which vars?  
-  ansible.builtin.debug:
-    msg: "{{ maas_open_tcp_ports }}"
-
 - name: Open tcp ports 
   ansible.builtin.iptables:
     chain: INPUT

--- a/roles/maas_firewall/tasks/setup_firewall_rules.yaml
+++ b/roles/maas_firewall/tasks/setup_firewall_rules.yaml
@@ -50,7 +50,7 @@
     protocol: tcp
     destination_port: "{{ item }}"
     jump: ACCEPT
-  with_items: "{{ maas_open_tcp_ports }}"
+  with_items: '{{ maas_open_tcp_ports|select() }}'
   when: maas_open_tcp_ports 
 
 - name: Open udp ports 

--- a/roles/maas_firewall/tasks/setup_firewall_rules.yaml
+++ b/roles/maas_firewall/tasks/setup_firewall_rules.yaml
@@ -44,6 +44,10 @@
     chain: FORWARD
     policy: DROP
 
+- name: Check which vars?  
+  ansible.builtin.debug:
+    msg: "{{ maas_open_tcp_ports }}"
+
 - name: Open tcp ports 
   ansible.builtin.iptables:
     chain: INPUT

--- a/roles/maas_postgres_primary/tasks/main.yaml
+++ b/roles/maas_postgres_primary/tasks/main.yaml
@@ -9,6 +9,10 @@
   import_tasks:
     configure_postgres_primary.yaml
 
+- name: Check the condition
+  ansible.builtin.debug:
+    msg: "{{ 'maas_region_controller' not in group_names }}" 
+
 - name: "Setup firewall"
   ansible.builtin.include_role:
     name: maas_firewall

--- a/roles/maas_postgres_primary/tasks/main.yaml
+++ b/roles/maas_postgres_primary/tasks/main.yaml
@@ -9,10 +9,6 @@
   import_tasks:
     configure_postgres_primary.yaml
 
-- name: Check the condition
-  ansible.builtin.debug:
-    msg: "{{ 'maas_region_controller' not in group_names }}" 
-
 - name: "Setup firewall"
   ansible.builtin.include_role:
     name: maas_firewall

--- a/roles/maas_proxy/tasks/main.yml
+++ b/roles/maas_proxy/tasks/main.yml
@@ -22,3 +22,4 @@
   ansible.builtin.include_role:
     name: maas_firewall
     tasks_from: setup_firewall_rules
+  when: ('maas_region_controller' not in group_names and 'maas_rack_controller' not in group_names)


### PR DESCRIPTION
Quick fix for issue MAAS fails at database migrations

Issue appears to be caused caused by firewall tasks closing ports which prevents database migration and successful install 

Added logic to open correct ports or delay locking host down before playbook run is complete, as needed