### PR TITLE
(ci): use ansible-lint config

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,6 +1,5 @@
 ---
 # .ansible-lint
 
-profile: null
 exclude_paths:
   - .github/

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,3 +3,7 @@
 
 exclude_paths:
   - .github/
+
+# skip_list to skip error when package state=latest
+skip_list:
+  - '403'

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,6 @@
+---
+# .ansible-lint
+
+profile: null
+exclude_paths:
+  - .github/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,5 +8,3 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run ansible-lint
         uses: ansible-community/ansible-lint-action@main
-        with:
-          path: "playbooks/"  # <-- only one value is allowed unfortunately

--- a/createadmin.yaml
+++ b/createadmin.yaml
@@ -1,17 +1,17 @@
 ---
 # Add (admin) user to already existing installation
 
-- hosts: maas_region_controller 
-  tasks:    
+- hosts: maas_region_controller
+  tasks:
     - name: "Create admin"
       ansible.builtin.expect:
-        command: maas createadmin 
+        command: maas createadmin
         responses:
           "(?i)Username: ": "{{ user_name }}"
           "(?i)Password: ": "{{ user_pwd }}"
           "(?i)Again: ": "{{ user_pwd }}"
           "(?i)Email:": "{{ user_email }}"
-          "(?i)Import SSH keys": "{{ user_ssh }}" 
+          "(?i)Import SSH keys": "{{ user_ssh }}"
   become: true
   no_log: true
   gather_facts: true

--- a/group_vars/all
+++ b/group_vars/all
@@ -42,13 +42,13 @@ maas_postgres_uri: "{{ maas_postgres_proxy_uri if maas_proxy_postgres_proxy_enab
 
 maas_postgres_backup_dir: "/tmp/maas_backup/" 
 maas_postgres_backup_path: "{{ maas_postgres_backup_dir }}dump.sql.gz"
-maas_config_backup_path: "{{ '/etc/maas/' if maas_install_deb|bool else '' }}"
-maas_runtime_backup_path: "{{ '/var/lib/maas/' if maas_install_deb|bool else '' }}"
-maas_exclude_backup_path: "{{ '/var/lib/maas/boot-resources/' if maas_install_deb|bool else '' }}"
+maas_config_backup_path: "{{ '/etc/maas/' if maas_install_deb | bool else '' }}"
+maas_runtime_backup_path: "{{ '/var/lib/maas/' if maas_install_deb | bool else '' }}"
+maas_exclude_backup_path: "{{ '/var/lib/maas/boot-resources/' if maas_install_deb | bool else '' }}"
 maas_backup_dest_path: "/tmp/{{ inventory_hostname }}_maas_backup_{{ ansible_date_time.iso8601 }}.tgz"
-maas_restore_config_path: "{{ '/etc/maas' if maas_install_deb|bool else '' }}"
-maas_restore_runtime_path: "{{ '/var/lib/maas' if maas_install_deb|bool else '' }}"
+maas_restore_config_path: "{{ '/etc/maas' if maas_install_deb | bool else '' }}"
+maas_restore_runtime_path: "{{ '/var/lib/maas' if maas_install_deb | bool else '' }}"
 
-maas_secret_file: "{{ '/var/snap/maas/common' if  maas_installation_type|lower == 'snap' else '/var/lib' }}/maas/secret"
+maas_secret_file: "{{ '/var/snap/maas/common' if  maas_installation_type | lower == 'snap' else '/var/lib' }}/maas/secret"
 
-maas_installmetric_file: "{{ '/var/snap/maas/common' if maas_installation_type|lower == 'snap' else '/var/lib/maas' }}/.ansible"
+maas_installmetric_file: "{{ '/var/snap/maas/common' if maas_installation_type | lower == 'snap' else '/var/lib/maas' }}/.ansible"

--- a/group_vars/maas_postgres
+++ b/group_vars/maas_postgres
@@ -1,5 +1,5 @@
 # postgres version number
-maas_postgres_version_number: "{{ 14 if ansible_facts.distribution_release == 'jammy' and maas_version|float > 3.2 else 12 }}"
+maas_postgres_version_number: "{{ 14 if ansible_facts.distribution_release == 'jammy' and maas_version | float > 3.2 else 12 }}"
 
 # latest compatible deb version of postgres
 maas_postgres_deb_name: "postgresql-{{ maas_postgres_version_number }}"

--- a/group_vars/maas_rack_controller
+++ b/group_vars/maas_rack_controller
@@ -4,7 +4,7 @@ maas_installation_type: "snap"  # snap or deb
 maas_snap_channel: "stable"     # if using snap, then the channel. ie: stable, beta, edge
 maas_deb_state: "present"       # if using deb, the state for install
 enable_tls: false                # whether to enable tls for this instance
-maas_package_name: "{{ 'maas' if (not maas_install_deb|bool) else 'maas-rack-controller' }}"
+maas_package_name: "{{ 'maas' if (not maas_install_deb | bool) else 'maas-rack-controller' }}"
 
 maas_open_tcp_ports: 
 - 53		# dns

--- a/group_vars/maas_region_controller
+++ b/group_vars/maas_region_controller
@@ -1,4 +1,4 @@
-maas_package_name: "{{ 'maas' if (not maas_install_deb|bool) else 'maas-region-api' }}"
+maas_package_name: "{{ 'maas' if (not maas_install_deb | bool) else 'maas-region-api' }}"
 
 # MAAS installation setup
 enable_tls: false               # If an operator wishes to enable TLS

--- a/roles/common/tasks/TLS.yaml
+++ b/roles/common/tasks/TLS.yaml
@@ -2,17 +2,17 @@
 # handle TLS setup, config, and enabling
 
 - name: Set default file locations if none given
-  set_fact:
+  ansible.builtin.set_fact:
     tls_key_path: "{{ tls_key_path | default(/etc/ssl/private/maas_tls.pem) }}"
     tls_cert_path: "{{ tls_cert_path | default(/etc/ssl/crt/maas_tls.crt) }}"
 
 - name: Check if a certificate exists
-  stat:
+  ansible.builtin.stat:
     path: "{{ tls_cert_path }}"
   register: tls_cert_stat
 
 - name: Check if a key exists
-  stat:
+  ansible.builtin.stat:
     path: "{{ tls_key_path }}"
   register: tls_key_stat
 

--- a/roles/common/tasks/TLS.yaml
+++ b/roles/common/tasks/TLS.yaml
@@ -3,8 +3,8 @@
 
 - name: Set default file locations if none given
   ansible.builtin.set_fact:
-    tls_key_path: "{{ tls_key_path | default(/etc/ssl/private/maas_tls.pem) }}"
-    tls_cert_path: "{{ tls_cert_path | default(/etc/ssl/crt/maas_tls.crt) }}"
+    tls_key_path: "{{ tls_key_path | default('/etc/ssl/private/maas_tls.pem') }}"
+    tls_cert_path: "{{ tls_cert_path | default('/etc/ssl/crt/maas_tls.crt') }}"
 
 - name: Check if a certificate exists
   ansible.builtin.stat:
@@ -30,3 +30,4 @@
 
 - name: Configure TLS
   ansible.builtin.command: maas config-tls enable {{ tls_key_path }} {{ tls_cert_path }}
+  changed_when: false

--- a/roles/common/tasks/backup.yaml
+++ b/roles/common/tasks/backup.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Generate List of Archiveable Directories
-  set_fact:
+  ansible.builtin.set_fact:
     archive_list: "{{ archive_list | default([]) + [item] }}"
   loop:
     - "{{ ('maas_postgres_primary' in group_names) | ternary('{{ maas_postgres_backup_dir }}', None) }}"

--- a/roles/common/tasks/backup.yaml
+++ b/roles/common/tasks/backup.yaml
@@ -1,11 +1,11 @@
 ---
 - name: Generate List of Archiveable Directories
   set_fact:
-    archive_list: "{{ archive_list|default([]) + [item] }}"
+    archive_list: "{{ archive_list | default([]) + [item] }}"
   loop:
     - "{{ ('maas_postgres_primary' in group_names) | ternary('{{ maas_postgres_backup_dir }}', None) }}"
-    - "{{ (('maas_region_controller' in group_names) or ('maas_rack_controller' in group_names)) | ternary('{{ maas_config_backup_path }}', None)  }}"
-    - "{{ (('maas_region_controller' in group_names) or ('maas_rack_controller' in group_names)) | ternary('{{ maas_runtime_backup_path }}', None)  }}"
+    - "{{ (('maas_region_controller' in group_names) or ('maas_rack_controller' in group_names)) | ternary('{{ maas_config_backup_path }}', None) }}"
+    - "{{ (('maas_region_controller' in group_names) or ('maas_rack_controller' in group_names)) | ternary('{{ maas_runtime_backup_path }}', None) }}"
   when: item
 
 - name: Bundle Backup Assets

--- a/roles/common/tasks/backup.yaml
+++ b/roles/common/tasks/backup.yaml
@@ -11,14 +11,17 @@
 - name: Bundle Backup Assets
   community.general.archive:
     path: "{{ archive_list }}"
+    mode: 0644
     exclude_path:
       - "{{ maas_exclude_backup_path }}"
     dest: "{{ maas_backup_dest_path }}"
 
 # ansible.builtin.fetch has the ability to be oom killed on large files, so we're using scp instead
 - name: Download Backup
-  local_action: "ansible.builtin.command scp {{ ansible_user }}@{{ inventory_hostname }}:{{ maas_backup_dest_path }} {{ maas_backup_download_path }}"
+  ansible.builtin.command: scp {{ ansible_user }}@{{ inventory_hostname }}:{{ maas_backup_dest_path }} {{ maas_backup_download_path }}
+  delegate_to: localhost
   become: false # don't need sudo locally
+  changed_when: false
 
 - name: Remove Backup from Remote Host
   ansible.builtin.file:

--- a/roles/common/tasks/metrics.yaml
+++ b/roles/common/tasks/metrics.yaml
@@ -23,7 +23,9 @@
   when: maas_state | lower == 'absent'
 
 - name: Make agent executable
-  ansible.builtin.file: dest=/opt/agent/agent-linux-amd64 mode=a+x
+  ansible.builtin.file:
+      path: /opt/agent/agent-linux-amd64
+      mode: 'a+x'
   when: maas_state | lower != 'absent'
 
 - name: Create agent directories

--- a/roles/common/tasks/metrics.yaml
+++ b/roles/common/tasks/metrics.yaml
@@ -3,33 +3,34 @@
 
 - name: Set the TCP port for grafana
   ansible.builtin.command: maas {{ admin_username }} maas set-config name=promtail_port value=5238
+  changed_when: false
 
-- name: enable syslog forwarding
+- name: Enable syslog forwarding
   ansible.builtin.command: maas {{ admin_username }} maas set-config name=promtail_enabled value=true
-  when: 'maas_state|lower != "absent"'
+  when: 'maas_state | lower != "absent"'
 
 - name: Download and unzip grafana agent
   ansible.builtin.unarchive:
       src: "{{ grafana_agent_pkg }}"
       dest: /opt/agent
       remote_src: true
-  when: maas_state|lower != 'absent'
+  when: maas_state | lower != 'absent'
 
 - name: Remove grafana agent pkg
   ansible.builtin.file:
       path: /opt/agent
       state: 'absent'
-  when: maas_state|lower == 'absent'
+  when: maas_state | lower == 'absent'
 
 - name: Make agent executable
   ansible.builtin.file: dest=/opt/agent/agent-linux-amd64 mode=a+x
-  when: maas_state|lower != 'absent'
+  when: maas_state | lower != 'absent'
 
 - name: Create agent directories
   ansible.builtin.file:
       path: "{{ item.src }}"
       state: "{{ 'directory' if maas_state | lower != 'absent' else maas_state }}"
-      mode: '0755'
+      mode: 0755
   loop:
       - {src: "/var/lib/grafana-agent/positions"}
       - {src: "/var/lib/grafana-agent/wal"}
@@ -38,7 +39,8 @@
   ansible.builtin.copy:
       src: /snap/maas/current/usr/share/maas/grafana_agent/agent.yaml.example
       dest: /opt/agent/agent.yml
-  when: maas_state|lower != 'absent'
+      mode: 0644
+  when: maas_state | lower != 'absent'
 
 - name: Start the grafana agent
   ansible.builtin.service:
@@ -46,7 +48,7 @@
       args: -E HOSTNAME="$(hostname)" \
             -E AGENT_WAL_DIR="/var/lib/grafana-agent/wal" \
             -E AGENT_POS_DIR="/var/lib/grafana-agent/positions" \
-            -E MAAS_LOGS={%- if maas_install_deb | bool -%} "/var/log/maas"{%- else -%}"/var/snap/maas/common/log/" %- endif -%} \
+            -E MAAS_LOGS={%- if maas_install_deb | bool -%} "/var/log/maas"{%- else -%}"/var/snap/maas/common/log/" {%- endif -%} \
             -E MAAS_IS_REGION="true" \
             -E MAAS_IS_RACK="false" \
             -E MAAS_AZ="default" \

--- a/roles/common/tasks/metrics.yaml
+++ b/roles/common/tasks/metrics.yaml
@@ -22,7 +22,7 @@
   when: maas_state|lower == 'absent'
 
 - name: Make agent executable
-  file: dest=/opt/agent/agent-linux-amd64 mode=a+x
+  ansible.builtin.file: dest=/opt/agent/agent-linux-amd64 mode=a+x
   when: maas_state|lower != 'absent'
 
 - name: Create agent directories

--- a/roles/common/tasks/metrics.yaml
+++ b/roles/common/tasks/metrics.yaml
@@ -28,7 +28,7 @@
 - name: Create agent directories
   ansible.builtin.file:
       path: "{{ item.src }}"
-      state: "{{ 'directory' if maas_state|lower != 'absent' else maas_state }}"
+      state: "{{ 'directory' if maas_state | lower != 'absent' else maas_state }}"
       mode: '0755'
   loop:
       - {src: "/var/lib/grafana-agent/positions"}
@@ -46,7 +46,7 @@
       args: -E HOSTNAME="$(hostname)" \
             -E AGENT_WAL_DIR="/var/lib/grafana-agent/wal" \
             -E AGENT_POS_DIR="/var/lib/grafana-agent/positions" \
-            -E MAAS_LOGS={%- if maas_install_deb|bool -%} "/var/log/maas" {%- else -%} "/var/snap/maas/common/log/" {%- endif -%} \
+            -E MAAS_LOGS={%- if maas_install_deb | bool -%} "/var/log/maas"{%- else -%}"/var/snap/maas/common/log/" %- endif -%} \
             -E MAAS_IS_REGION="true" \
             -E MAAS_IS_RACK="false" \
             -E MAAS_AZ="default" \
@@ -54,4 +54,4 @@
                 -config.expand-env \
                 -config.file=/opt/agent/agent.yml
       enabled: true
-      state: "{{ 'started' if maas_state|lower != 'absent' else 'stopped' }}"
+      state: "{{ 'started' if maas_state | lower != 'absent' else 'stopped' }}"

--- a/roles/common/tasks/metrics.yaml
+++ b/roles/common/tasks/metrics.yaml
@@ -50,7 +50,7 @@
       args: -E HOSTNAME="$(hostname)" \
             -E AGENT_WAL_DIR="/var/lib/grafana-agent/wal" \
             -E AGENT_POS_DIR="/var/lib/grafana-agent/positions" \
-            -E MAAS_LOGS={%- if maas_install_deb | bool -%} "/var/log/maas"{%- else -%}"/var/snap/maas/common/log/" {%- endif -%} \
+            -E MAAS_LOGS={%- if maas_install_deb | bool -%} "/var/log/maas"{%- else -%} "/var/snap/maas/common/log/"{%- endif -%} \
             -E MAAS_IS_REGION="true" \
             -E MAAS_IS_RACK="false" \
             -E MAAS_AZ="default" \

--- a/roles/common/tasks/restore.yaml
+++ b/roles/common/tasks/restore.yaml
@@ -16,17 +16,17 @@
   ansible.builtin.systemd:
     name: maas-regiond.service
     state: stopped
-  when: ('maas_region_controller' in group_names) and maas_install_deb|bool
+  when: ('maas_region_controller' in group_names) and maas_install_deb | bool
 
 - name: Stop Rack Controller
   ansible.builtin.systemd:
     name: maas-rackd.service
     state: stopped
-  when: ('maas_rack_controller' in group_names) and maas_install_deb|bool
+  when: ('maas_rack_controller' in group_names) and maas_install_deb | bool
 
 - name: Stop MAAS snap
   ansible.builtin.command: snap stop maas
-  when: (('maas_region_controller' in group_names) or ('maas_rack_controller' in group_names)) and (not maas_install_deb|bool)
+  when: (('maas_region_controller' in group_names) or ('maas_rack_controller' in group_names)) and (not maas_install_deb | bool)
 
 - name: Restore Config
   ansible.builtin.command: "mv /tmp/maas_backup/etc/maas {{ maas_restore_config_path }}"
@@ -40,14 +40,14 @@
   ansible.builtin.systemd:
     name: maas-regiond.service
     state: started
-  when: ('maas_region_controller' in group_names) and maas_install_deb|bool
+  when: ('maas_region_controller' in group_names) and maas_install_deb | bool
 
 - name: Start Rack Controller
   ansible.builtin.systemd:
     name: maas-rackd.service
     state: started
-  when: ('maas_rack_controller' in group_names) and maas_install_deb|bool
+  when: ('maas_rack_controller' in group_names) and maas_install_deb | bool
 
 - name: Start MAAS snap
   ansible.builtin.command: snap start maas
-  when: (('maas_region_controller' in group_names) or ('maas_rack_controller' in group_names)) and (not maas_install_deb|bool)
+  when: (('maas_region_controller' in group_names) or ('maas_rack_controller' in group_names)) and (not maas_install_deb | bool)

--- a/roles/common/tasks/vault.yaml
+++ b/roles/common/tasks/vault.yaml
@@ -2,7 +2,10 @@
 # Enable the use of vault on MAAS
 
 - name: Configure MAAS Vault
-  ansible.builtin.command: maas config-vault configure {{ vault_url }} {{ vault_approle_id }} {{ vault_wrapped_token }} {{ vault_secrets_path }} --secrets-mount {{ vault_secret_mount }}
+  ansible.builtin.command: >
+    maas config-vault configure {{ vault_url }} {{ vault_approle_id }}
+    {{ vault_wrapped_token }} {{ vault_secrets_path }}
+    --secrets-mount {{ vault_secret_mount }}
 
 - name: Migrate MAAS secrets
   ansible.builtin.command: maas config-vault migrate-secrets

--- a/roles/common/tasks/vault.yaml
+++ b/roles/common/tasks/vault.yaml
@@ -6,6 +6,8 @@
     maas config-vault configure {{ vault_url }} {{ vault_approle_id }}
     {{ vault_wrapped_token }} {{ vault_secrets_path }}
     --secrets-mount {{ vault_secret_mount }}
+  changed_when: false
 
 - name: Migrate MAAS secrets
   ansible.builtin.command: maas config-vault migrate-secrets
+  changed_when: false

--- a/roles/maas_firewall/tasks/setup_firewall_rules.yaml
+++ b/roles/maas_firewall/tasks/setup_firewall_rules.yaml
@@ -5,12 +5,12 @@
     chain: OUTPUT
     protocol: tcp
     destination_port: 22
-    jump: ACCEPT    
+    jump: ACCEPT
 
 - name: Allow incoming port 22
   ansible.builtin.iptables:
     chain: INPUT
-    protocol: tcp 
+    protocol: tcp
     destination_port: 22
     jump: ACCEPT
 
@@ -25,39 +25,39 @@
     chain: INPUT
     protocol: tcp
     destination_port: 53
-    jump: ACCEPT    
+    jump: ACCEPT
 
 - name: Allow port 53 tcp/udp
   ansible.builtin.iptables:
     chain: INPUT
-    protocol: udp 
-    destination_port: 53 
-    jump: ACCEPT    
+    protocol: udp
+    destination_port: 53
+    jump: ACCEPT
 
 - name: Set policy for INPUT chain to drop (otherwise)
   ansible.builtin.iptables:
     chain: INPUT
     policy: DROP
 
-- name: Set policy for FORWARD chain to drop 
+- name: Set policy for FORWARD chain to drop
   ansible.builtin.iptables:
     chain: FORWARD
     policy: DROP
 
-- name: Open tcp ports 
+- name: Open tcp ports
   ansible.builtin.iptables:
     chain: INPUT
     protocol: tcp
     destination_port: "{{ item }}"
     jump: ACCEPT
   with_items: '{{ maas_open_tcp_ports|select() }}'
-  when: maas_open_tcp_ports 
+  when: maas_open_tcp_ports
 
-- name: Open udp ports 
+- name: Open udp ports
   ansible.builtin.iptables:
     chain: INPUT
     protocol: udp
     destination_port: "{{ item }}"
     jump: ACCEPT
   with_items: "{{ maas_open_udp_ports }}"
-  when: maas_open_udp_ports 
+  when: maas_open_udp_ports

--- a/roles/maas_firewall/tasks/setup_firewall_rules.yaml
+++ b/roles/maas_firewall/tasks/setup_firewall_rules.yaml
@@ -50,7 +50,7 @@
     protocol: tcp
     destination_port: "{{ item }}"
     jump: ACCEPT
-  with_items: '{{ maas_open_tcp_ports|select() }}'
+  with_items: '{{ maas_open_tcp_ports | select() }}'
   when: maas_open_tcp_ports
 
 - name: Open udp ports

--- a/roles/maas_firewall/tasks/teardown.yaml
+++ b/roles/maas_firewall/tasks/teardown.yaml
@@ -13,4 +13,4 @@
 
 - name: Flush all other rules
   ansible.builtin.iptables:
-    flush: yes
+    flush: true

--- a/roles/maas_postgres/tasks/install_postgres.yml
+++ b/roles/maas_postgres/tasks/install_postgres.yml
@@ -8,24 +8,24 @@
   ansible.builtin.apt:
     name: libpq-dev
     update_cache: true # update cache still if pip was already installed
-    state: "{{ 'present' if maas_postgres_action|lower == 'install' else maas_postgres_action }}"
+    state: "{{ 'present' if maas_postgres_action | lower == 'install' else maas_postgres_action }}"
 
 - name: "Install psycopg2 For Configuration"
   ansible.builtin.pip:
     name: "psycopg2"
     version: "2.9.3"
-    state: "{{ 'present' if maas_postgres_action|lower == 'install' else maas_postgres_action }}"
+    state: "{{ 'present' if maas_postgres_action | lower == 'install' else maas_postgres_action }}"
 
 - name: "Install acl to become postgres user"
   ansible.builtin.apt:
     name: acl
-    state: "{{ 'present' if maas_postgres_action|lower == 'install' else maas_postgres_action }}"
+    state: "{{ 'present' if maas_postgres_action | lower == 'install' else maas_postgres_action }}"
 
 - name: "Install Postgres"
   ansible.builtin.apt:
     name: "{{ maas_postgres_deb_name }}"
     update_cache: true # update cache still if previous packages are already installed
-    state: "{{ 'present' if maas_postgres_action|lower == 'install' else maas_postgres_action }}"
+    state: "{{ 'present' if maas_postgres_action | lower == 'install' else maas_postgres_action }}"
 
 - name: "Write pg_hba.conf"
   ansible.builtin.template:
@@ -51,7 +51,7 @@
 - name: "Create MAAS Postgres Database"
   community.postgresql.postgresql_db:
     name: "{{ maas_postgres_database }}"
-    state: "{{ 'present' if maas_postgres_action|lower == 'install' else maas_postgres_action }}"
+    state: "{{ 'present' if maas_postgres_action | lower == 'install' else maas_postgres_action }}"
     owner: "{{ maas_postgres_user }}"
   become: yes
   become_user: postgres

--- a/roles/maas_postgres/tasks/install_postgres.yml
+++ b/roles/maas_postgres/tasks/install_postgres.yml
@@ -53,5 +53,5 @@
     name: "{{ maas_postgres_database }}"
     state: "{{ 'present' if maas_postgres_action | lower == 'install' else maas_postgres_action }}"
     owner: "{{ maas_postgres_user }}"
-  become: yes
+  become: true
   become_user: postgres

--- a/roles/maas_postgres/tasks/restore.yaml
+++ b/roles/maas_postgres/tasks/restore.yaml
@@ -6,4 +6,3 @@
     target: "{{ maas_postgres_backup_path }}"
   become: true
   become_user: postgres
-

--- a/roles/maas_postgres/tasks/teardown.yaml
+++ b/roles/maas_postgres/tasks/teardown.yaml
@@ -27,4 +27,4 @@
   ansible.builtin.pip:
     name: "psycopg2"
     state: absent
-  ignore_errors: true
+  failed_when: false

--- a/roles/maas_postgres/tasks/teardown.yaml
+++ b/roles/maas_postgres/tasks/teardown.yaml
@@ -1,10 +1,10 @@
 ---
 - name: Set postgres number for uninstall
-  ansible.builtin.set_fact:
+  ansible.builtin.ansible.builtin.set_fact:
     maas_postgres_version_number: "{{ 14 if ansible_facts.distribution_release == 'jammy' and maas_version | float > 3.2 else 12 }}"
 
 - name: Setting config dirs for uninstall
-  ansible.builtin.set_fact:
+  ansible.builtin.ansible.builtin.set_fact:
     maas_postgres_config_dir: "/etc/postgresql/{{ maas_postgres_version_number }}/main/"
 
 - name: "Uninstall Postgres"

--- a/roles/maas_postgres/tasks/teardown.yaml
+++ b/roles/maas_postgres/tasks/teardown.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Set postgres number for uninstall
   ansible.builtin.set_fact:
-    maas_postgres_version_number: "{{ 14 if ansible_facts.distribution_release == 'jammy' and maas_version|float > 3.2 else 12 }}"
+    maas_postgres_version_number: "{{ 14 if ansible_facts.distribution_release == 'jammy' and maas_version | float > 3.2 else 12 }}"
 
 - name: Setting config dirs for uninstall
   ansible.builtin.set_fact:

--- a/roles/maas_postgres/tasks/teardown.yaml
+++ b/roles/maas_postgres/tasks/teardown.yaml
@@ -1,10 +1,10 @@
 ---
 - name: Set postgres number for uninstall
-  ansible.builtin.ansible.builtin.set_fact:
+  ansible.builtin.set_fact:
     maas_postgres_version_number: "{{ 14 if ansible_facts.distribution_release == 'jammy' and maas_version | float > 3.2 else 12 }}"
 
 - name: Setting config dirs for uninstall
-  ansible.builtin.ansible.builtin.set_fact:
+  ansible.builtin.set_fact:
     maas_postgres_config_dir: "/etc/postgresql/{{ maas_postgres_version_number }}/main/"
 
 - name: "Uninstall Postgres"

--- a/roles/maas_postgres/tasks/write_postgres_config.yaml
+++ b/roles/maas_postgres/tasks/write_postgres_config.yaml
@@ -11,11 +11,11 @@
   ansible.builtin.systemd:
     name: "postgresql@{{ maas_postgres_version_number }}-main.service"
     state: stopped
-    no_block: no # wait for clean stop
+    no_block: false # wait for clean stop
 
 - name: "Start Postgres Service To Load New Configuration"
   ansible.builtin.systemd:
     name: "postgresql@{{ maas_postgres_version_number }}-main.service"
     enabled: true
     state: started
-    no_block: no
+    no_block: false

--- a/roles/maas_postgres_primary/tasks/configure_postgres_primary.yaml
+++ b/roles/maas_postgres_primary/tasks/configure_postgres_primary.yaml
@@ -1,13 +1,9 @@
 ---
 
 - name: "Generate Replication Password"
-  ansible.builtin.shell: openssl rand -base64 14
+  ansible.builtin.command: openssl rand -base64 14
   register: maas_postgres_replication_password_output
   when: maas_postgres_replication_password is undefined
-
-- name: Print rep password 
-  ansible.builtin.debug:
-    var: maas_postgres_replication_password_output
 
 - name: "Save Replication Password"
   ansible.builtin.set_fact:

--- a/roles/maas_postgres_primary/tasks/configure_postgres_primary.yaml
+++ b/roles/maas_postgres_primary/tasks/configure_postgres_primary.yaml
@@ -6,7 +6,7 @@
   when: maas_postgres_replication_password is undefined
 
 - name: "Save Replication Password"
-  set_fact:
+  ansible.builtin.set_fact:
     maas_postgres_replication_password: "{{ maas_postgres_replication_password_output.stdout }}"
     cacheable: true
   run_once: true

--- a/roles/maas_postgres_primary/tasks/configure_postgres_primary.yaml
+++ b/roles/maas_postgres_primary/tasks/configure_postgres_primary.yaml
@@ -19,7 +19,7 @@
     name: "{{ maas_postgres_replication_user }}"
     password: "{{ maas_postgres_replication_password }}"
     role_attr_flags: replication
-    state: "{{ 'present' if maas_postgres_action|lower == 'install' else maas_postgres_action }}"
+    state: "{{ 'present' if maas_postgres_action | lower == 'install' else maas_postgres_action }}"
   become: true
   become_user: postgres
 
@@ -27,7 +27,7 @@
   community.postgresql.postgresql_slot:
     name: "{{ maas_postgres_replication_slot }}"
     db: "maasdb"
-    state: "{{ 'present' if maas_postgres_action|lower == 'install' else maas_postgres_action }}"
+    state: "{{ 'present' if maas_postgres_action | lower == 'install' else maas_postgres_action }}"
   become: true
   become_user: postgres
   register: maas_postgres_enable_sync

--- a/roles/maas_postgres_primary/tasks/configure_postgres_primary.yaml
+++ b/roles/maas_postgres_primary/tasks/configure_postgres_primary.yaml
@@ -5,6 +5,10 @@
   register: maas_postgres_replication_password_output
   when: maas_postgres_replication_password is undefined
 
+- name: Print rep password 
+  ansible.builtin.debug:
+    var: maas_postgres_replication_password_output
+
 - name: "Save Replication Password"
   ansible.builtin.set_fact:
     maas_postgres_replication_password: "{{ maas_postgres_replication_password_output.stdout }}"

--- a/roles/maas_postgres_primary/tasks/main.yaml
+++ b/roles/maas_postgres_primary/tasks/main.yaml
@@ -6,7 +6,7 @@
     tasks_from: install_postgres
 
 - name: "Configure Postgres Primary"
-  import_tasks:
+  ansible.builtin.import_tasks:
     configure_postgres_primary.yaml
 
 - name: "Setup firewall"

--- a/roles/maas_postgres_secondary/tasks/configure_postgres_secondary.yaml
+++ b/roles/maas_postgres_secondary/tasks/configure_postgres_secondary.yaml
@@ -21,7 +21,10 @@
 
 - name: "Create Base Backup"
   ansible.builtin.expect:
-    command: "pg_basebackup -h {{ maas_postgres_primary_address }} -U {{ maas_postgres_replication_user }} -P -p 5432 -D {{ maas_postgres_data_dir }} -Fp -Xs -R"
+    command: >
+      "pg_basebackup -h {{ maas_postgres_primary_address }}"
+      "-U {{ maas_postgres_replication_user }} -P"
+      "-p 5432 -D {{ maas_postgres_data_dir }} -Fp -Xs -R"
     responses:
       '(?i)password': "{{ maas_postgres_replication_password }}"
   when: maas_postgres_action == "install"

--- a/roles/maas_postgres_secondary/tasks/configure_postgres_secondary.yaml
+++ b/roles/maas_postgres_secondary/tasks/configure_postgres_secondary.yaml
@@ -17,7 +17,7 @@
     owner: postgres
     group: postgres
     mode: '0700'
-  when: maas_postgres_action|lower == 'install'
+  when: maas_postgres_action | lower == 'install'
 
 - name: "Create Base Backup"
   ansible.builtin.expect:
@@ -37,7 +37,8 @@
     dest: "{{ maas_postgres_config_dir }}recovery.conf"
     owner: postgres
     group: postgres
-  when: maas_postgres_action|lower == 'install'
+    mode: 0644
+  when: maas_postgres_action | lower == 'install'
 
 - name: "Start Postgres in Hot Standby"
   ansible.builtin.systemd:

--- a/roles/maas_postgres_secondary/tasks/configure_postgres_secondary.yaml
+++ b/roles/maas_postgres_secondary/tasks/configure_postgres_secondary.yaml
@@ -22,9 +22,9 @@
 - name: "Create Base Backup"
   ansible.builtin.expect:
     command: >
-      "pg_basebackup -h {{ maas_postgres_primary_address }}"
-      "-U {{ maas_postgres_replication_user }} -P"
-      "-p 5432 -D {{ maas_postgres_data_dir }} -Fp -Xs -R"
+      pg_basebackup -h {{ maas_postgres_primary_address }}
+      -U {{ maas_postgres_replication_user }} -P
+      -p 5432 -D {{ maas_postgres_data_dir }} -Fp -Xs -R
     responses:
       '(?i)password': "{{ maas_postgres_replication_password }}"
   when: maas_postgres_action == "install"

--- a/roles/maas_postgres_secondary/tasks/main.yaml
+++ b/roles/maas_postgres_secondary/tasks/main.yaml
@@ -6,7 +6,7 @@
     tasks_from: install_postgres
 
 - name: "Configure Postgres Secondary"
-  import_tasks:
+  ansible.builtin.import_tasks:
     configure_postgres_secondary.yaml
 
 - name: "Setup firewall"

--- a/roles/maas_postgres_secondary/tasks/teardown.yaml
+++ b/roles/maas_postgres_secondary/tasks/teardown.yaml
@@ -2,5 +2,5 @@
 
 - name: "Remove Previous Data Directory"
   ansible.builtin.file:
-    path: "{{ maas_postgres_data_dir | default( '/var/snap/maas-test-db/common/postgres/data/' ) }}"
+    path: "{{ maas_postgres_data_dir | default('/var/snap/maas-test-db/common/postgres/data/') }}"
     state: 'absent'

--- a/roles/maas_proxy/tasks/main.yml
+++ b/roles/maas_proxy/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: "Install HAProxy"
   ansible.builtin.apt:
     name: haproxy
-    state: "{{ 'present' if maas_proxy_state|lower == 'install' else maas_proxy_state }}"
+    state: "{{ 'present' if maas_proxy_state | lower == 'install' else maas_proxy_state }}"
 
 - name: "Write HAProxy Config"
   ansible.builtin.template:

--- a/roles/maas_rack_controller/tasks/install_maas.yaml
+++ b/roles/maas_rack_controller/tasks/install_maas.yaml
@@ -4,12 +4,12 @@
   community.general.snap:
     name: maas
     channel: '{{ maas_version }}/{{ maas_snap_channel }}'
-  when: (maas_installation_type|lower == 'snap') and ('maas_region_controller' not in group_names)
+  when: (maas_installation_type | lower == 'snap') and ('maas_region_controller' not in group_names)
 
 - name: Add MAAS apt Respository
   ansible.builtin.apt_repository:
     repo: "ppa:maas/{{ maas_version }}"
-  when: (maas_installation_type|lower == 'deb') and ('maas_region_controller' not in group_names)
+  when: (maas_installation_type | lower == 'deb') and ('maas_region_controller' not in group_names)
 
 - name: Create MAAS Unix Group
   ansible.builtin.group:
@@ -26,21 +26,21 @@
   ansible.builtin.apt:
     name: chrony
     state: present
-  when: (maas_installation_type|lower == 'deb')
+  when: (maas_installation_type | lower == 'deb')
 
 - name: Install MAAS Rack Controller
   ansible.builtin.apt:
     name: maas-rack-controller
     state: "{{ maas_deb_state | default('present') }}"
-  when: (maas_installation_type|lower == 'deb')
+  when: (maas_installation_type | lower == 'deb')
 
 - name: Initialise MAAS Rack Controller
   ansible.builtin.command: maas init --mode=rack --maas-url={{ maas_url }} --secret={{ maas_rack_secret }}
-  when: (maas_installation_type|lower == 'snap') and ('maas_region_controller' not in group_names)
+  when: (maas_installation_type | lower == 'snap') and ('maas_region_controller' not in group_names)
 
 - name: Initialise MAAS Rack Controller
   ansible.builtin.command: maas-rack register --url={{ maas_url }} --secret={{ maas_rack_secret }}
-  when: (maas_installation_type|lower == 'deb')
+  when: (maas_installation_type | lower == 'deb')
 
 - name: Enable TLS
   ansible.builtin.include_role:

--- a/roles/maas_rack_controller/tasks/install_maas.yaml
+++ b/roles/maas_rack_controller/tasks/install_maas.yaml
@@ -31,7 +31,7 @@
 - name: Install MAAS Rack Controller
   ansible.builtin.apt:
     name: maas-rack-controller
-    state: "{{ maas_deb_state|default('present') }}"
+    state: "{{ maas_deb_state | default('present') }}"
   when: (maas_installation_type|lower == 'deb')
 
 - name: Initialise MAAS Rack Controller

--- a/roles/maas_rack_controller/tasks/install_maas.yaml
+++ b/roles/maas_rack_controller/tasks/install_maas.yaml
@@ -49,9 +49,9 @@
   # TLS is available only in MAAS 3.2 or higher
   when: maas_version is version("3.2", '>=') and enable_tls
 
-- name: Create metrics file  
+- name: Create metrics file
   ansible.builtin.file:
     path: "{{ maas_installmetric_file }}"
-    state: touch 
+    state: touch
     mode: 0644
   when: install_metrics

--- a/roles/maas_rack_controller/tasks/main.yaml
+++ b/roles/maas_rack_controller/tasks/main.yaml
@@ -5,15 +5,15 @@
   when: maas_url | length == 0
 
 - name: "Check if MAAS is installed"
-  package_facts:
+  ansible.builtin.package_facts:
     manager: "auto"
 
 - name: "Install MAAS rack controller"
-  import_tasks: install_maas.yaml
+  ansible.builtin.import_tasks: install_maas.yaml
   when: (maas_package_name not in ansible_facts.packages)
 
 - name: "Update MAAS rack controller"
-  import_tasks: upgrade_maas.yaml
+  ansible.builtin.import_tasks: upgrade_maas.yaml
   when: (maas_package_name in ansible_facts.packages)
 
 - name: Install metrics

--- a/roles/maas_rack_controller/tasks/main.yaml
+++ b/roles/maas_rack_controller/tasks/main.yaml
@@ -21,7 +21,7 @@
     name: common
     tasks_from: metrics
   when: install_metrics is defined and install_metrics
- 
+
 - name: "Setup firewall"
   ansible.builtin.include_role:
     name: maas_firewall

--- a/roles/maas_rack_controller/tasks/upgrade_maas.yaml
+++ b/roles/maas_rack_controller/tasks/upgrade_maas.yaml
@@ -1,22 +1,22 @@
 ---
 - name: Update MAAS - Snap
   ansible.builtin.command: snap refresh --channel={{ maas_version }} maas
-  when: maas_installation_type|lower == 'snap'
+  when: maas_installation_type | lower == 'snap'
 
 - name: Add MAAS apt Respository
   ansible.builtin.apt_repository:
     repo: "ppa:maas/{{ maas_version }}"
-  when: maas_installation_type|lower == 'deb'
+  when: maas_installation_type | lower == 'deb'
 
-- name: Install Deb Dependancy
+- name: Install Deb Dependency
   ansible.builtin.apt:
     name: chrony
     state: latest
-  when: (maas_installation_type|lower == 'deb')
+  when: (maas_installation_type | lower == 'deb')
 
 - name: Install MAAS Rack Controller
   ansible.builtin.apt:
     name: "maas-rack-controller"
     state: latest
     update_cache: true
-  when: (maas_installation_type|lower == 'deb')
+  when: (maas_installation_type | lower == 'deb')

--- a/roles/maas_rack_controller/tasks/upgrade_maas.yaml
+++ b/roles/maas_rack_controller/tasks/upgrade_maas.yaml
@@ -18,5 +18,5 @@
   ansible.builtin.apt:
     name: "maas-rack-controller"
     state: latest
-    update_cache: yes
+    update_cache: true
   when: (maas_installation_type|lower == 'deb')

--- a/roles/maas_region_controller/tasks/install_maas.yaml
+++ b/roles/maas_region_controller/tasks/install_maas.yaml
@@ -5,7 +5,7 @@
   community.general.snap:
     name: maas
     channel: '{{ maas_version }}/{{ maas_snap_channel }}'
-    state: "{{ 'present' if maas_state|lower == 'install' else maas_state }}"
+    state: "{{ 'present' if maas_state | lower == 'install' else maas_state }}"
   register: maas_region_new_installation
   when: maas_installation_type|lower == 'snap'
 
@@ -17,7 +17,7 @@
 - name: Install MAAS Region Controller - Deb
   ansible.builtin.apt:
     name: "maas-region-api"
-    state: "{{ maas_deb_state|default('present') }}"
+    state: "{{ maas_deb_state | default('present') }}"
     update_cache: true
   register: maas_region_new_installation
   when: (maas_installation_type|lower == 'deb')
@@ -36,12 +36,12 @@
   when: maas_installation_type|lower == 'snap' and maas_region_new_installation is defined
 
 - name: Migrate MAAS database
-  ansible.builtin.command: "{{ 'maas' if maas_installation_type|lower == 'snap' else 'maas-region' }} migrate"
+  ansible.builtin.command: "{{ 'maas' if maas_installation_type | lower == 'snap' else 'maas-region' }} migrate"
 
 # MAAS region controller only needs to be initialized in this case if rbac or candid are in use, otherwise the reigond.conf write handles init
 - name: Initialise MAAS Controller - Deb
   ansible.builtin.expect:
-    command: "maas init --rbac-url={{ maas_rbac_url|default('')|quote }} --candid-agent-file={{ maas_candid_auth_file|default('')|quote }} --admin-ssh-import={{ admin_id }}"
+    command: "maas init --rbac-url={{ maas_rbac_url | default('') | quote }} --candid-agent-file={{ maas_candid_auth_file | default('') | quote }} --admin-ssh-import={{ admin_id }}"
     responses:
       "(?i)Username: ": "{{ admin_username }}"
       "(?i)Password: ": "{{ admin_password }}"

--- a/roles/maas_region_controller/tasks/install_maas.yaml
+++ b/roles/maas_region_controller/tasks/install_maas.yaml
@@ -7,12 +7,12 @@
     channel: '{{ maas_version }}/{{ maas_snap_channel }}'
     state: "{{ 'present' if maas_state | lower == 'install' else maas_state }}"
   register: maas_region_new_installation
-  when: maas_installation_type|lower == 'snap'
+  when: maas_installation_type | lower == 'snap'
 
 - name: Add MAAS apt Respository
   ansible.builtin.apt_repository:
     repo: "ppa:maas/{{ maas_version }}"
-  when: maas_installation_type|lower == 'deb'
+  when: maas_installation_type | lower == 'deb'
 
 - name: Install MAAS Region Controller - Deb
   ansible.builtin.apt:
@@ -20,7 +20,7 @@
     state: "{{ maas_deb_state | default('present') }}"
     update_cache: true
   register: maas_region_new_installation
-  when: (maas_installation_type|lower == 'deb')
+  when: (maas_installation_type | lower == 'deb')
 
 - name: Update regiond.conf
   ansible.builtin.template:
@@ -29,7 +29,7 @@
     mode: 0644
     owner: maas
     group: maas
-  when: maas_installation_type|lower == 'deb'
+  when: maas_installation_type | lower == 'deb'
 
 - name: Initialise MAAS Controller - Snap
   ansible.builtin.command: >
@@ -37,10 +37,11 @@
     {{ 'region+rack' if 'maas_rack_controller' in group_names else 'region' }}
     --maas-url={{ maas_url }}
     --database-uri {{ maas_postgres_uri }}
-  when: maas_installation_type|lower == 'snap' and maas_region_new_installation is defined
+  when: maas_installation_type | lower == 'snap' and maas_region_new_installation is defined
 
 - name: Migrate MAAS database
   ansible.builtin.command: "{{ 'maas' if maas_installation_type | lower == 'snap' else 'maas-region' }} migrate"
+  changed_when: false
 
 # MAAS region controller only needs to be initialized in this case if rbac or candid are in use, otherwise the reigond.conf write handles init
 - name: Initialise MAAS Controller - Deb
@@ -54,14 +55,14 @@
       "(?i)Password: ": "{{ admin_password }}"
       "(?i)Again: ": "{{ admin_password }}"
       "(?i)Email: ": "{{ admin_email }}"
-  when: maas_installation_type|lower == 'deb' and maas_region_new_installation is defined
+  when: maas_installation_type | lower == 'deb' and maas_region_new_installation is defined
 
 - name: Starting MAAS region service
   ansible.builtin.systemd:
     name: maas-regiond.service
     state: started
     no_block: false
-  when: maas_installation_type|lower == 'deb'
+  when: maas_installation_type | lower == 'deb'
 
 - name: Define MAAS URL
   ansible.builtin.command: maas config | grep maas_url | cut -d "=" -f2
@@ -72,7 +73,7 @@
   ansible.builtin.command: maas createadmin \
    --username={{ admin_username }} --password={{ admin_password }} \
    --email={{ admin_email }} --ssh-import={{ admin_id }}
-  when: not maas_region_new_installation or maas_installation_type|lower == 'snap'
+  when: not maas_region_new_installation or maas_installation_type | lower == 'snap'
 
 - name: Enable TLS
   ansible.builtin.include_role:
@@ -89,6 +90,7 @@
 - name: Read MAAS Secret For Rack Controllers
   ansible.builtin.command: cat "{{ maas_secret_file }}"
   register: maas_rack_secret_tmp
+  changed_when: false
 
 - name: Save MAAS Secret
   ansible.builtin.set_fact:

--- a/roles/maas_region_controller/tasks/install_maas.yaml
+++ b/roles/maas_region_controller/tasks/install_maas.yaml
@@ -53,7 +53,7 @@
   ansible.builtin.systemd:
     name: maas-regiond.service
     state: started
-    no_block: no
+    no_block: false
   when: maas_installation_type|lower == 'deb'
 
 - name: Define MAAS URL
@@ -86,7 +86,7 @@
 - name: Save MAAS Secret
   ansible.builtin.set_fact:
     maas_rack_secret: "{{ maas_rack_secret_tmp.stdout }}"
-    cacheable: yes
+    cacheable: true
   run_once: true
   delegate_to: "{{ item }}"
   delegate_facts: true

--- a/roles/maas_region_controller/tasks/install_maas.yaml
+++ b/roles/maas_region_controller/tasks/install_maas.yaml
@@ -92,9 +92,9 @@
   delegate_facts: true
   loop: "{{ groups['maas_rack_controller'] }}"
 
-- name: Create metrics file  
+- name: Create metrics file
   ansible.builtin.file:
     path: "{{ maas_installmetric_file }}"
-    state: touch 
+    state: touch
     mode: 0644
-  when: install_metrics 
+  when: install_metrics

--- a/roles/maas_region_controller/tasks/install_maas.yaml
+++ b/roles/maas_region_controller/tasks/install_maas.yaml
@@ -47,9 +47,9 @@
 - name: Initialise MAAS Controller - Deb
   ansible.builtin.expect:
     command: >
-      "maas init --rbac-url={{ maas_rbac_url | default('') | quote }}"
-      "--candid-agent-file={{ maas_candid_auth_file | default('') | quote }}"
-      "--admin-ssh-import={{ admin_id }}"
+      maas init --rbac-url={{ maas_rbac_url | default('') | quote }}
+      --candid-agent-file={{ maas_candid_auth_file | default('') | quote }}
+      --admin-ssh-import={{ admin_id }}
     responses:
       "(?i)Username: ": "{{ admin_username }}"
       "(?i)Password: ": "{{ admin_password }}"

--- a/roles/maas_region_controller/tasks/install_maas.yaml
+++ b/roles/maas_region_controller/tasks/install_maas.yaml
@@ -32,7 +32,11 @@
   when: maas_installation_type|lower == 'deb'
 
 - name: Initialise MAAS Controller - Snap
-  ansible.builtin.command: maas init {{ 'region+rack' if 'maas_rack_controller' in group_names else 'region' }} --maas-url={{ maas_url }} --database-uri {{ maas_postgres_uri }}
+  ansible.builtin.command: >
+    maas init
+    {{ 'region+rack' if 'maas_rack_controller' in group_names else 'region' }}
+    --maas-url={{ maas_url }}
+    --database-uri {{ maas_postgres_uri }}
   when: maas_installation_type|lower == 'snap' and maas_region_new_installation is defined
 
 - name: Migrate MAAS database
@@ -41,7 +45,10 @@
 # MAAS region controller only needs to be initialized in this case if rbac or candid are in use, otherwise the reigond.conf write handles init
 - name: Initialise MAAS Controller - Deb
   ansible.builtin.expect:
-    command: "maas init --rbac-url={{ maas_rbac_url | default('') | quote }} --candid-agent-file={{ maas_candid_auth_file | default('') | quote }} --admin-ssh-import={{ admin_id }}"
+    command: >
+      "maas init --rbac-url={{ maas_rbac_url | default('') | quote }}"
+      "--candid-agent-file={{ maas_candid_auth_file | default('') | quote }}"
+      "--admin-ssh-import={{ admin_id }}"
     responses:
       "(?i)Username: ": "{{ admin_username }}"
       "(?i)Password: ": "{{ admin_password }}"

--- a/roles/maas_region_controller/tasks/install_maas.yaml
+++ b/roles/maas_region_controller/tasks/install_maas.yaml
@@ -84,7 +84,7 @@
   register: maas_rack_secret_tmp
 
 - name: Save MAAS Secret
-  set_fact:
+  ansible.builtin.set_fact:
     maas_rack_secret: "{{ maas_rack_secret_tmp.stdout }}"
     cacheable: yes
   run_once: true

--- a/roles/maas_region_controller/tasks/main.yaml
+++ b/roles/maas_region_controller/tasks/main.yaml
@@ -1,15 +1,15 @@
 ---
 # Playbook to generate a MAAS region
 - name: "Check if MAAS is installed"
-  package_facts:
+  ansible.builtin.package_facts:
     manager: "auto"
 
 - name: Install MAAS Region
-  import_tasks: install_maas.yaml
+  ansible.builtin.import_tasks: install_maas.yaml
   when: (maas_package_name not in ansible_facts.packages)
 
 - name: Update MAAS Region
-  import_tasks: update_maas.yaml
+  ansible.builtin.import_tasks: update_maas.yaml
   when: (maas_package_name in ansible_facts.packages)
 
 - name: Install MAAS metrics

--- a/roles/maas_region_controller/tasks/update_maas.yaml
+++ b/roles/maas_region_controller/tasks/update_maas.yaml
@@ -30,7 +30,7 @@
 - name: Save MAAS Secret
   ansible.builtin.set_fact:
     maas_rack_secret: "{{ maas_rack_secret_tmp.stdout }}"
-    cacheable: yes
+    cacheable: true
   run_once: true
   delegate_to: "{{ item }}"
   delegate_facts: true

--- a/roles/maas_region_controller/tasks/update_maas.yaml
+++ b/roles/maas_region_controller/tasks/update_maas.yaml
@@ -1,22 +1,23 @@
 ---
 - name: Update MAAS - Snap
   ansible.builtin.command: snap refresh --channel={{ maas_version }} maas
-  when: maas_installation_type|lower == 'snap'
+  when: maas_installation_type | lower == 'snap'
 
 - name: Add MAAS apt Respository
   ansible.builtin.apt_repository:
     repo: "ppa:maas/{{ maas_version }}"
-  when: maas_installation_type|lower == 'deb'
+  when: maas_installation_type | lower == 'deb'
 
 - name: Update MAAS - Deb
   ansible.builtin.apt:
     name: maas-region-api
     state: latest
     update_cache: true
-  when: maas_installation_type|lower == 'deb' and '"maas_rack_controller" not in group_names'
+  when: maas_installation_type | lower == 'deb' and '"maas_rack_controller" not in group_names'
 
 - name: Migrate MAAS database
   ansible.builtin.command: "{{ 'maas' if maas_installation_type | lower == 'snap' else 'maas-region' }} migrate"
+  changed_when: false
 
 - name: Wait For MAAS To Create Secret File
   ansible.builtin.wait_for:
@@ -26,6 +27,7 @@
 - name: Read MAAS Secret For Rack Controllers
   ansible.builtin.command: cat "{{ maas_secret_file }}"
   register: maas_rack_secret_tmp
+  changed_when: false
 
 - name: Save MAAS Secret
   ansible.builtin.set_fact:

--- a/roles/maas_region_controller/tasks/update_maas.yaml
+++ b/roles/maas_region_controller/tasks/update_maas.yaml
@@ -28,7 +28,7 @@
   register: maas_rack_secret_tmp
 
 - name: Save MAAS Secret
-  set_fact:
+  ansible.builtin.set_fact:
     maas_rack_secret: "{{ maas_rack_secret_tmp.stdout }}"
     cacheable: yes
   run_once: true

--- a/roles/maas_region_controller/tasks/update_maas.yaml
+++ b/roles/maas_region_controller/tasks/update_maas.yaml
@@ -16,7 +16,7 @@
   when: maas_installation_type|lower == 'deb' and '"maas_rack_controller" not in group_names'
 
 - name: Migrate MAAS database
-  ansible.builtin.command: "{{ 'maas' if maas_installation_type|lower == 'snap' else 'maas-region' }} migrate"
+  ansible.builtin.command: "{{ 'maas' if maas_installation_type | lower == 'snap' else 'maas-region' }} migrate"
 
 - name: Wait For MAAS To Create Secret File
   ansible.builtin.wait_for:

--- a/teardown.yaml
+++ b/teardown.yaml
@@ -7,7 +7,7 @@
   tasks:
 
   - name: "Collect facts about installed packages"
-    package_facts:
+    ansible.builtin.package_facts:
       manager: auto
       strategy: all
 


### PR DESCRIPTION
Because of the `ansible-lint-action` [limitation](https://github.com/ansible/ansible-lint-action/pull/97) (it can take only one path), it is impossible to pass multiple folders (e.g. roles or group_vars).

This commit changes the logic, making `ansible-lint` to take configuration from the [configuration file](https://ansible-lint.readthedocs.io/configuring/#ansible-lint-configuration).

This should resolve https://github.com/maas/maas-ansible-playbook/issues/42

P.S. There are lots of linter issues that needs to be fixed, I'm not that good with Ansible...