### PR TITLE
Fix secret issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # MAAS-ansible-playbook
-An Ansible playbook for installing and configuring MAAS, further documentation is found [here](https://maas.io/docs/ansible-playbooks-reference).
+An Ansible playbook for installing and configuring MAAS
 
 ## Install
 
@@ -59,14 +59,14 @@ This playbook requires a user to set the following set of variables:
 
 - **maas_installation_type**: The intended type of MAAS installation. Possible values are: 'deb' or 'snap'
 
-- **maas_url**: The MAAS URL MAAS will be accessed and rack controllers should use for registering with region controllers. Example: 'http://proxy01.example.com:5240/MAAS'
+- **maas_url**: The MAAS URL where MAAS will be accessed and which the rack controllers should use for registering with region controllers. Example: 'http://proxy01.example.com:5240/MAAS'
 
 ### Deploy the MAAS stack
 
 ```
 ansible-playbook -i ./hosts\
-    --extra-vars="maas_version=3.2 maas_postgres_password=example maas_installation_type=deb maas_url=http://example.com:5240/MAAS"\
-    ./site.yaml
+    --extra-vars="maas_version=3.2 maas_postgres_password=example maas_installation_type=deb maas_url=http://example.com:5240/MAAS\
+    ./site.yaml"
 ```
 
 ### Teardown the MAAS stack
@@ -80,7 +80,7 @@ ansible-playbook -i ./hosts ./teardown.yaml
 Backup MAAS requires the `maas_backup_download_path` variable to be set, it will designate a path local to where the playbook is being run to download backup archives. This path must exist prior to running the playbook. `maas_installation_type` is also required.
 
 ```
-ansible-playbook -i ./hosts --extra-vars="maas_backup_download_path=/tmp/maas_backups/ maas_installation_type=deb" ./backup.yaml
+ansible-playbook -i ./hosts --extra-vars="maas_backup_download_path=/tmp/maas_backups/ maas_installation_type=deb" ./backup.yaml"
 ```
 
 ### Restore from Backup

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # MAAS-ansible-playbook
-An Ansible playbook for installing and configuring MAAS
+An Ansible playbook for installing and configuring MAAS, further documentation is found [here](https://maas.io/docs/ansible-playbooks-reference).
 
 ## Install
 
@@ -59,14 +59,14 @@ This playbook requires a user to set the following set of variables:
 
 - **maas_installation_type**: The intended type of MAAS installation. Possible values are: 'deb' or 'snap'
 
-- **maas_url**: The MAAS URL where MAAS will be accessed and which the rack controllers should use for registering with region controllers. Example: 'http://proxy01.example.com:5240/MAAS'
+- **maas_url**: The MAAS URL where MAAS will be accessed and which rack controllers should use for registering with region controllers. Example: 'http://proxy01.example.com:5240/MAAS'
 
 ### Deploy the MAAS stack
 
 ```
 ansible-playbook -i ./hosts\
-    --extra-vars="maas_version=3.2 maas_postgres_password=example maas_installation_type=deb maas_url=http://example.com:5240/MAAS\
-    ./site.yaml"
+    --extra-vars="maas_version=3.2 maas_postgres_password=example maas_installation_type=deb maas_url=http://example.com:5240/MAAS"\
+    ./site.yaml
 ```
 
 ### Teardown the MAAS stack
@@ -80,7 +80,7 @@ ansible-playbook -i ./hosts ./teardown.yaml
 Backup MAAS requires the `maas_backup_download_path` variable to be set, it will designate a path local to where the playbook is being run to download backup archives. This path must exist prior to running the playbook. `maas_installation_type` is also required.
 
 ```
-ansible-playbook -i ./hosts --extra-vars="maas_backup_download_path=/tmp/maas_backups/ maas_installation_type=deb" ./backup.yaml"
+ansible-playbook -i ./hosts --extra-vars="maas_backup_download_path=/tmp/maas_backups/ maas_installation_type=deb" ./backup.yaml
 ```
 
 ### Restore from Backup

--- a/roles/maas_rack_controller/tasks/install_maas.yaml
+++ b/roles/maas_rack_controller/tasks/install_maas.yaml
@@ -35,7 +35,7 @@
   when: (maas_installation_type | lower == 'deb')
 
 - name: Initialise MAAS Rack Controller
-  ansible.builtin.command: maas init --mode=rack --maas-url={{ maas_url }} --secret={{ maas_rack_secret }}
+  ansible.builtin.command: maas init rack --maas-url={{ maas_url }} --secret={{ maas_rack_secret }}
   when: (maas_installation_type | lower == 'snap') and ('maas_region_controller' not in group_names)
 
 - name: Initialise MAAS Rack Controller

--- a/roles/maas_rack_controller/tasks/install_maas.yaml
+++ b/roles/maas_rack_controller/tasks/install_maas.yaml
@@ -6,7 +6,7 @@
     channel: '{{ maas_use_version }}/{{ maas_snap_channel }}'
   when: (maas_installation_type | lower == 'snap') and ('maas_region_controller' not in group_names)
 
-- name: Add MAAS apt Respository
+- name: Add MAAS apt Repository
   ansible.builtin.apt_repository:
     repo: "ppa:maas/{{ maas_use_version }}"
   when: (maas_installation_type | lower == 'deb') and ('maas_region_controller' not in group_names)
@@ -22,7 +22,7 @@
     group: maas
     state: present
 
-- name: Install Deb Dependancy
+- name: Install Deb Dependency
   ansible.builtin.apt:
     name: chrony
     state: present

--- a/roles/maas_rack_controller/tasks/upgrade_maas.yaml
+++ b/roles/maas_rack_controller/tasks/upgrade_maas.yaml
@@ -3,7 +3,7 @@
   ansible.builtin.command: snap refresh --channel={{ maas_use_version }} maas
   when: maas_installation_type | lower == 'snap'
 
-- name: Add MAAS apt Respository
+- name: Add MAAS apt Repository
   ansible.builtin.apt_repository:
     repo: "ppa:maas/{{ maas_use_version }}"
   when: maas_installation_type | lower == 'deb'

--- a/roles/maas_region_controller/tasks/install_maas.yaml
+++ b/roles/maas_region_controller/tasks/install_maas.yaml
@@ -100,7 +100,7 @@
   delegate_to: "{{ item }}"
   delegate_facts: true
   loop: "{{ groups['maas_rack_controller'] }}"
-  when: ('maas_rack_controller' in group_names)
+  when: ('maas_rack_controller' not in group_names)
 
 - name: Create metrics file
   ansible.builtin.file:

--- a/roles/maas_region_controller/tasks/install_maas.yaml
+++ b/roles/maas_region_controller/tasks/install_maas.yaml
@@ -9,7 +9,7 @@
   register: maas_region_new_installation
   when: maas_installation_type | lower == 'snap'
 
-- name: Add MAAS apt Respository
+- name: Add MAAS apt Repository
   ansible.builtin.apt_repository:
     repo: "ppa:maas/{{ maas_use_version }}"
   when: maas_installation_type | lower == 'deb'

--- a/roles/maas_region_controller/tasks/update_maas.yaml
+++ b/roles/maas_region_controller/tasks/update_maas.yaml
@@ -3,7 +3,7 @@
   ansible.builtin.command: snap refresh --channel={{ maas_use_version }} maas
   when: maas_installation_type | lower == 'snap'
 
-- name: Add MAAS apt Respository
+- name: Add MAAS apt Repository
   ansible.builtin.apt_repository:
     repo: "ppa:maas/{{ maas_use_version }}"
   when: maas_installation_type | lower == 'deb'


### PR DESCRIPTION
This attempts to fix a few issues I ran into

In general: there was issue with region and rack on separate hosts, where it seemed that the maas_rack_secret wasn't defined other than on the region controller host causing the rack controller initialisation to fail

snap install: failed on initialising when region and rack controllers on separate hosts: changed the command

Also fixed some typos I spotted across the playbook 

Please double check my fixes, feedback welcome 
