### PR TITLE
Update version checking for postgres

### DIFF
--- a/group_vars/maas_postgres
+++ b/group_vars/maas_postgres
@@ -1,5 +1,5 @@
 # postgres version number
-maas_postgres_version_number: "{{ 14 if ansible_distribution_major_version | float >= 22 and maas_use_version is version('3.2', '>') else 12 }}"
+maas_postgres_version_number: "{{ 14 if ansible_distribution_major_version | float >= 22 and maas_use_version is version('3.2', '>=') else 12 }}"
 
 # latest compatible deb version of postgres
 maas_postgres_deb_name: "postgresql-{{ maas_postgres_version_number }}"


### PR DESCRIPTION
we should use psql 14 for 3.2 and up, not just versions greater than 3.2