### PR TITLE
fix deprecation warning

### DIFF
--- a/group_vars/maas_postgres_primary
+++ b/group_vars/maas_postgres_primary
@@ -5,8 +5,8 @@ maas_postgres_ipv4_netmask: "{{ ansible_default_ipv4['netmask'] if 'netmask' in 
 maas_postgres_ipv6_prefixlen: "{{ ansible_default_ipv6['prefixlen'] if 'prefixlen' in ansible_default_ipv6 else '128' }}"
 maas_postgres_replication_v4_cidr: "{{ maas_postgres_ipv4 }}/{{ maas_postgres_ipv4_netmask }}"
 maas_postgres_replication_v6_cidr: "{{ maas_postgres_ipv6 }}/{{ maas_postgres_ipv6_prefixlen }}"
-maas_postgres_replication_v4_subnet: "{{ maas_postgres_ipv4 }}/{{ maas_postgres_replication_v4_cidr | ipaddr('prefix') }}"
-maas_postgres_replication_v6_subnet: "{{ maas_postgres_replication_v6_cidr | ipaddr('prefix') }}"
+maas_postgres_replication_v4_subnet: "{{ maas_postgres_ipv4 }}/{{ maas_postgres_replication_v4_cidr | ansible.utils.ipaddr('prefix') }}"
+maas_postgres_replication_v6_subnet: "{{ maas_postgres_replication_v6_cidr | ansible.utils.ipaddr('prefix') }}"
 maas_postgres_hba_entries:
   local:
     - type: 'local'


### PR DESCRIPTION
Change to ipaddr to use fully qualified name to get rid of deprecation warning in 'maas_postgres : Write pg_hba.conf' task. 

Related to #64 