### PR TITLE
Remove maas version magic

### DIFF
--- a/backup.yaml
+++ b/backup.yaml
@@ -2,7 +2,7 @@
 - hosts: maas_postgres_primary
   tasks:
     - name: Backup Postgres
-      include_role:
+      ansible.builtin.include_role:
         name: maas_postgres
         tasks_from: backup
   become: true
@@ -16,7 +16,7 @@
     - maas_rack_controller
   tasks:
     - name: Archive and Download Backups
-      include_role:
+      ansible.builtin.include_role:
         name: common
         tasks_from: backup
   become: true

--- a/group_vars/all
+++ b/group_vars/all
@@ -54,9 +54,12 @@ maas_installmetric_file: "{{ '/var/snap/maas/common' if maas_installation_type |
 # Operating system releases and the minimum version of MAAS they can run
 supported_distributions:
   Ubuntu:
-    "22.04": # Jammy and up supports any version of MAAS
+    "22.04":  # Jammy supports MAAS >= 3.3
       max: "any"
-      min: "any"
-    "0.0": # MAAS 3.2 requires lower than jammy
-      max: "3.2"
+      min: "3.3"
+    "20.04":  # Focal supports MAAS >= 2.9 and < 3.3
+      max: "3.3"
+      min: "2.9"
+    "0.0":    # Versions below Focal are used for MAAS < 2.9
+      max: "2.9"
       min: "any"

--- a/group_vars/all
+++ b/group_vars/all
@@ -3,7 +3,6 @@
 # Standard MAAS Variables
 maas_port: 5240             # The port MAAS uses to comunicate on
 maas_https_port: 5443       # The https port MAAS uses to comunicate on
-maas_url: ""                # The URL MAAS uses
 enable_tls: false           # Use TLS for MAAS communication
 vault_integration: false    # Use MAAS vault for secret storage
 install_metrics: false           # install metrics for the MAAS
@@ -17,7 +16,6 @@ vault_secret_mount: ""
 
 # Installation variables
 maas_install_deb: "{{ maas_installation_type == 'deb' }}"
-maas_version: "latest"          # ie: 3.2, 2.8
 maas_snap_channel: "stable"     # if using snap, then the channel. ie: stable, beta, edge
 maas_deb_state: "present"       # if using deb, the state for install
 maas_state: "install"           # whether to install, or upgrade maas

--- a/group_vars/all
+++ b/group_vars/all
@@ -50,3 +50,13 @@ maas_restore_runtime_path: "{{ '/var/lib/maas' if maas_install_deb | bool else '
 maas_secret_file: "{{ '/var/snap/maas/common' if  maas_installation_type | lower == 'snap' else '/var/lib' }}/maas/secret"
 
 maas_installmetric_file: "{{ '/var/snap/maas/common' if maas_installation_type | lower == 'snap' else '/var/lib/maas' }}/.ansible"
+
+# Operating system releases and the minimum version of MAAS they can run
+supported_distributions:
+  Ubuntu:
+    "22.04": # Jammy and up supports any version of MAAS
+      max: "any"
+      min: "any"
+    "0.0": # MAAS 3.2 requires lower than jammy
+      max: "3.2"
+      min: "any"

--- a/group_vars/maas_postgres
+++ b/group_vars/maas_postgres
@@ -1,5 +1,5 @@
 # postgres version number
-maas_postgres_version_number: "{{ 14 if ansible_distribution_major_version | float >= 22 and maas_use_version is version('3.2', '>=') else 12 }}"
+maas_postgres_version_number: "{{ 14 if ansible_distribution_major_version | float >= 22 and maas_version is version('3.2', '>=') else 12 }}"
 
 # latest compatible deb version of postgres
 maas_postgres_deb_name: "postgresql-{{ maas_postgres_version_number }}"

--- a/group_vars/maas_rack_controller
+++ b/group_vars/maas_rack_controller
@@ -1,6 +1,4 @@
 # MAAS installation setup
-maas_version: "latest"          # ie: 3.2, 2.8
-maas_installation_type: "snap"  # snap or deb
 maas_snap_channel: "stable"     # if using snap, then the channel. ie: stable, beta, edge
 maas_deb_state: "present"       # if using deb, the state for install
 enable_tls: false                # whether to enable tls for this instance

--- a/restore.yaml
+++ b/restore.yaml
@@ -5,7 +5,7 @@
     - maas_rack_controller
   tasks:
     - name: Restore from backup
-      include_role:
+      ansible.builtin.include_role:
         name: common
         tasks_from: restore
   become: true
@@ -14,7 +14,7 @@
 - hosts: maas_postgres_primary
   tasks:
     - name: Restore from database dump
-      include_role:
+      ansible.builtin.include_role:
         name: maas_postgres
         tasks_from: restore
   become: true

--- a/roles/common/tasks/maas_supported_os.yaml
+++ b/roles/common/tasks/maas_supported_os.yaml
@@ -1,15 +1,20 @@
 ---
 # If the distibution is not in the supported dictionary
-- assert:
+- ansible.builtin.assert:
+    name: "Verify Distro supported"
     fail_msg: "MAAS cannot be installed on {{ ansible_distribution }}!"
     that:
       - ansible_distribution in supported_distributions
 
 # fetch the highest release number in the dictionary that is equal or less than the host release number
-- set_fact: closest_distro_version={{ supported_distributions[ansible_distribution][supported_distributions[ansible_distribution].keys() | community.general.version_sort | reject('>', ansible_distribution_version | string) | last] }}
+- ansible.builtin.assertset_fact:
+    name: "Fetch highest supported distro verison"
+    closest_distro_version: "{{ supported_distributions[ansible_distribution][supported_distributions[ansible_distribution].keys() | community.general.version_sort | reject('>', ansible_distribution_version | string) | last] }}"
 
 # Make sure our maas version is within the minimum and maximum supported version numbers
-- assert:
+- ansible.builtin.assert:
+    name: "Verify version supports installed MAAS"
     fail_msg: "MAAS {{ maas_version }} is not compatible with {{ ansible_distribution }}-{{ ansible_distribution_version }}"
     that:
-      - maas_version is version(closest_distro_version["max"] | string | replace("any", "9999"), "<=") and maas_version is version(closest_distro_version["min"] | string | replace("any", "0.0"), ">=")
+      - (maas_version is version(closest_distro_version["max"] | string | replace("any", "9999"), "<=")) and
+        (maas_version is version(closest_distro_version["min"] | string | replace("any", "0.0"), ">="))

--- a/roles/common/tasks/maas_supported_os.yaml
+++ b/roles/common/tasks/maas_supported_os.yaml
@@ -1,19 +1,20 @@
 ---
 # If the distibution is not in the supported dictionary
-- ansible.builtin.assert:
-    name: "Verify Distro supported"
+- name: "Verify Distro supported"
+  ansible.builtin.assert:
     fail_msg: "MAAS cannot be installed on {{ ansible_distribution }}!"
     that:
       - ansible_distribution in supported_distributions
 
 # fetch the highest release number in the dictionary that is equal or less than the host release number
-- ansible.builtin.assertset_fact:
-    name: "Fetch highest supported distro verison"
-    closest_distro_version: "{{ supported_distributions[ansible_distribution][supported_distributions[ansible_distribution].keys() | community.general.version_sort | reject('>', ansible_distribution_version | string) | last] }}"
+- name: "Fetch highest supported distro verison"
+  ansible.builtin.assertset_fact:
+    closest_distro_version: "{{ supported_distributions[ansible_distribution][supported_distributions[ansible_distribution].keys()
+      | community.general.version_sort | reject('>', ansible_distribution_version | string) | last] }}"
 
 # Make sure our maas version is within the minimum and maximum supported version numbers
-- ansible.builtin.assert:
-    name: "Verify version supports installed MAAS"
+- name: "Verify version supports installed MAAS"
+  ansible.builtin.assert:
     fail_msg: "MAAS {{ maas_version }} is not compatible with {{ ansible_distribution }}-{{ ansible_distribution_version }}"
     that:
       - (maas_version is version(closest_distro_version["max"] | string | replace("any", "9999"), "<=")) and

--- a/roles/common/tasks/maas_supported_os.yaml
+++ b/roles/common/tasks/maas_supported_os.yaml
@@ -17,5 +17,5 @@
   ansible.builtin.assert:
     fail_msg: "MAAS {{ maas_version }} is not compatible with {{ ansible_distribution }}-{{ ansible_distribution_version }}"
     that:
-      - (maas_version is version(closest_distro_version["max"] | string | replace("any", "9999"), "<=")) and
+      - (maas_version is version(closest_distro_version["max"] | string | replace("any", "9999"), "<")) and
         (maas_version is version(closest_distro_version["min"] | string | replace("any", "0.0"), ">="))

--- a/roles/common/tasks/maas_supported_os.yaml
+++ b/roles/common/tasks/maas_supported_os.yaml
@@ -1,0 +1,15 @@
+---
+# If the distibution is not in the supported dictionary
+- assert:
+    fail_msg: "MAAS cannot be installed on {{ ansible_distribution }}!"
+    that:
+      - ansible_distribution in supported_distributions
+
+# fetch the highest release number in the dictionary that is equal or less than the host release number
+- set_fact: closest_distro_version={{ supported_distributions[ansible_distribution][supported_distributions[ansible_distribution].keys() | community.general.version_sort | reject('>', ansible_distribution_version | string) | last] }}
+
+# Make sure our maas version is within the minimum and maximum supported version numbers
+- assert:
+    fail_msg: "MAAS {{ maas_version }} is not compatible with {{ ansible_distribution }}-{{ ansible_distribution_version }}"
+    that:
+      - maas_version is version(closest_distro_version["max"] | string | replace("any", "9999"), "<=") and maas_version is version(closest_distro_version["min"] | string | replace("any", "0.0"), ">=")

--- a/roles/maas_postgres/tasks/teardown.yaml
+++ b/roles/maas_postgres/tasks/teardown.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Set postgres number for uninstall
   ansible.builtin.set_fact:
-    maas_postgres_version_number: "{{ 14 if ansible_distribution_major_version | float >= 22 and maas_use_version is version('3.2', '>=') else 12 }}"
+    maas_postgres_version_number: "{{ 14 if ansible_distribution_major_version | float >= 22 and maas_version is version('3.2', '>=') else 12 }}"
 
 - name: Setting config dirs for uninstall
   ansible.builtin.set_fact:

--- a/roles/maas_rack_controller/tasks/install_maas.yaml
+++ b/roles/maas_rack_controller/tasks/install_maas.yaml
@@ -3,12 +3,12 @@
 - name: Install MAAS - Snap
   community.general.snap:
     name: maas
-    channel: '{{ maas_use_version }}/{{ maas_snap_channel }}'
+    channel: '{{ maas_version }}/{{ maas_snap_channel }}'
   when: (maas_installation_type | lower == 'snap') and ('maas_region_controller' not in group_names)
 
 - name: Add MAAS apt Repository
   ansible.builtin.apt_repository:
-    repo: "ppa:maas/{{ maas_use_version }}"
+    repo: "ppa:maas/{{ maas_version }}"
   when: (maas_installation_type | lower == 'deb') and ('maas_region_controller' not in group_names)
 
 - name: Create MAAS Unix Group
@@ -47,7 +47,7 @@
     name: common
     tasks_from: TLS
   # TLS is available only in MAAS 3.2 or higher
-  when: maas_use_version is version("3.2", '>=') and enable_tls
+  when: maas_version is version("3.2", '>=') and enable_tls
 
 - name: Create metrics file
   ansible.builtin.file:

--- a/roles/maas_rack_controller/tasks/main.yaml
+++ b/roles/maas_rack_controller/tasks/main.yaml
@@ -1,4 +1,10 @@
 ---
+# Playbook to generate a MAAS region
+- name: Verify MAAS Version supported on OS
+  ansible.builtin.include_role:
+    name: common
+    tasks_from: maas_supported_os
+
 - name: "Check MAAS Url supplied by user or region controller setup"
   ansible.builtin.fail:
     msg: "MAAS Url not found"

--- a/roles/maas_rack_controller/tasks/main.yaml
+++ b/roles/maas_rack_controller/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
 # Playbook to generate a MAAS region
-- name: Verify MAAS Version supported on OS
+- name: Verify MAAS Version supported on the host OS
   ansible.builtin.include_role:
     name: common
     tasks_from: maas_supported_os

--- a/roles/maas_rack_controller/tasks/upgrade_maas.yaml
+++ b/roles/maas_rack_controller/tasks/upgrade_maas.yaml
@@ -1,11 +1,11 @@
 ---
 - name: Update MAAS - Snap
-  ansible.builtin.command: snap refresh --channel={{ maas_use_version }}/{{ maas_snap_channel }} maas
+  ansible.builtin.command: snap refresh --channel={{ maas_version }}/{{ maas_snap_channel }} maas
   when: maas_installation_type | lower == 'snap'
 
 - name: Add MAAS apt Repository
   ansible.builtin.apt_repository:
-    repo: "ppa:maas/{{ maas_use_version }}"
+    repo: "ppa:maas/{{ maas_version }}"
   when: maas_installation_type | lower == 'deb'
 
 - name: Install Deb Dependency

--- a/roles/maas_region_controller/tasks/install_maas.yaml
+++ b/roles/maas_region_controller/tasks/install_maas.yaml
@@ -4,14 +4,14 @@
 - name: Install MAAS - Snap
   community.general.snap:
     name: maas
-    channel: '{{ maas_use_version }}/{{ maas_snap_channel }}'
+    channel: '{{ maas_version }}/{{ maas_snap_channel }}'
     state: "{{ 'present' if maas_state | lower == 'install' else maas_state }}"
   register: maas_region_new_installation
   when: maas_installation_type | lower == 'snap'
 
 - name: Add MAAS apt Repository
   ansible.builtin.apt_repository:
-    repo: "ppa:maas/{{ maas_use_version }}"
+    repo: "ppa:maas/{{ maas_version }}"
   when: maas_installation_type | lower == 'deb'
 
 - name: Install MAAS Region Controller - Deb
@@ -64,11 +64,6 @@
     no_block: false
   when: maas_installation_type | lower == 'deb'
 
-- name: Define MAAS URL
-  ansible.builtin.command: maas config | grep maas_url | cut -d "=" -f2
-  register: maas_url
-  when: not maas_url
-
 - name: Add an administrator to MAAS
   ansible.builtin.command: maas createadmin \
    --username={{ admin_username }} --password={{ admin_password }} \
@@ -80,7 +75,7 @@
     name: common
     tasks_from: TLS
   # TLS is available only in MAAS 3.2 or higher
-  when: maas_use_version is version("3.2", '>=') and enable_tls
+  when: maas_version is version("3.2", '>=') and enable_tls
 
 - name: Wait For MAAS To Create Secret File
   ansible.builtin.wait_for:

--- a/roles/maas_region_controller/tasks/main.yaml
+++ b/roles/maas_region_controller/tasks/main.yaml
@@ -37,7 +37,7 @@
     name: common
     tasks_from: vault
   # Vault requires MAAS 3.3 or greater
-  when: vault_integration is defined and vault_integration and maas_use_version is version("3.3", '>=')
+  when: vault_integration is defined and vault_integration and maas_version is version("3.3", '>=')
 
 - name: "Setup firewall"
   ansible.builtin.include_role:

--- a/roles/maas_region_controller/tasks/main.yaml
+++ b/roles/maas_region_controller/tasks/main.yaml
@@ -1,5 +1,10 @@
 ---
 # Playbook to generate a MAAS region
+- name: Verify MAAS Version supported on OS
+  ansible.builtin.include_role:
+    name: common
+    tasks_from: maas_supported_os
+
 - name: Check installed packages
   ansible.builtin.package_facts:
     manager: "auto"

--- a/roles/maas_region_controller/tasks/main.yaml
+++ b/roles/maas_region_controller/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
 # Playbook to generate a MAAS region
-- name: Verify MAAS Version supported on OS
+- name: Verify MAAS Version supported on the host OS
   ansible.builtin.include_role:
     name: common
     tasks_from: maas_supported_os

--- a/roles/maas_region_controller/tasks/update_maas.yaml
+++ b/roles/maas_region_controller/tasks/update_maas.yaml
@@ -1,11 +1,11 @@
 ---
 - name: Update MAAS - Snap
-  ansible.builtin.command: snap refresh --channel={{ maas_use_version }}/{{ maas_snap_channel }} maas
+  ansible.builtin.command: snap refresh --channel={{ maas_version }}/{{ maas_snap_channel }} maas
   when: maas_installation_type | lower == 'snap'
 
 - name: Add MAAS apt Repository
   ansible.builtin.apt_repository:
-    repo: "ppa:maas/{{ maas_use_version }}"
+    repo: "ppa:maas/{{ maas_version }}"
   when: maas_installation_type | lower == 'deb'
 
 - name: Update MAAS - Deb

--- a/site.yaml
+++ b/site.yaml
@@ -4,7 +4,7 @@
 
 - hosts: all
   tasks:
-    - assert:
+    - ansible.builtin.assert:
         quiet: true
         fail_msg: "Required variable has not been defined"
         that:
@@ -13,7 +13,7 @@
           - maas_installation_type is defined
           - maas_postgres_password is defined
 
-    - assert:
+    - ansible.builtin.assert:
         fail_msg: "'{{ maas_version }}' is not a valid version number"
         that:
           - maas_version is regex('\d+\.\d+(\.\d+)?')

--- a/site.yaml
+++ b/site.yaml
@@ -5,7 +5,7 @@
 - hosts: all
   tasks:
     - assert:
-        giet: True
+        quiet: True
         fail_msg: "Required variable has not been defined"
         that:
           - maas_url is defined

--- a/site.yaml
+++ b/site.yaml
@@ -5,7 +5,7 @@
 - hosts: all
   tasks:
     - assert:
-        quiet: True
+        quiet: true
         fail_msg: "Required variable has not been defined"
         that:
           - maas_url is defined

--- a/site.yaml
+++ b/site.yaml
@@ -4,20 +4,19 @@
 
 - hosts: all
   tasks:
-  - name: Fetch MAAS Version if number not given
-    ansible.builtin.shell: "\
-      set -o pipefail && \
-      snap info maas | grep /{{ maas_snap_channel | default('stable') }} | \
-      awk -F ' ' '{print $2}' | sort -n | tail -n1 | grep -oP '[0-9]+(.[0-9]+)+'"
-    args:
-      executable: /bin/bash
-    register: maas_tmp_ver
-    when: (maas_version is not regex('[0-9]+.[0-9]+(.[0-9]+)?'))
+    - assert:
+        giet: True
+        fail_msg: "Required variable has not been defined"
+        that:
+          - maas_url is defined
+          - maas_version is defined
+          - maas_installation_type is defined
+          - maas_postgres_password is defined
 
-  - name: Register valid MAAS version
-    ansible.builtin.set_fact:
-      maas_use_version: "{{ maas_tmp_ver.stdout | regex_search('[0-9]+.[0-9]+') if maas_version is not regex('[0-9]+.[0-9]+(.[0-9]+)?') else maas_version }}"
-      cacheable: true
+    - assert:
+        fail_msg: "'{{ maas_version }}' is not a valid version number"
+        that:
+          - maas_version is regex('\d+\.\d+(\.\d+)?')
 
 - hosts: maas_postgres_primary
   roles:

--- a/site.yaml
+++ b/site.yaml
@@ -4,7 +4,8 @@
 
 - hosts: all
   tasks:
-    - ansible.builtin.assert:
+    - name: "Ensure required variables have been defined"
+      ansible.builtin.assert:
         quiet: true
         fail_msg: "Required variable has not been defined"
         that:
@@ -13,7 +14,8 @@
           - maas_installation_type is defined
           - maas_postgres_password is defined
 
-    - ansible.builtin.assert:
+    - name: "Ensure maas_version is a version string"
+      ansible.builtin.assert:
         fail_msg: "'{{ maas_version }}' is not a valid version number"
         that:
           - maas_version is regex('\d+\.\d+(\.\d+)?')

--- a/teardown.yaml
+++ b/teardown.yaml
@@ -12,7 +12,7 @@
       strategy: all
 
   - name: "Collect facts about system services"
-    service_facts:
+    ansible.builtin.service_facts:
 
   - name: "Remove iptables rules"
     ansible.builtin.include_role:


### PR DESCRIPTION
System-tests fixes incoming:
- Removed automatically setting `maas_version` from latest snap release:
  README.md would suggest `maas_version` is a required variable)
- Playbooks will now abort if any of the required variables are not set. (in `site.yaml`)
- Playbooks have a defined `supported_os_releases` dictionary in `group_vars/all` that is used to verify if a MAAS can be installed on the host image.