### PR TITLE
fix: introduce http_proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,59 +92,64 @@ all:
 
 This playbook requires a user to set the following set of variables:
 
-- **maas_version**: The intended version of MAAS to install. Example: '3.2'
+- **maas_version**: The intended version of MAAS to install.\
+  Example: `'3.2'`
 
-- **maas_postgres_password**: The password for the MAAS postgres user. Example: 'my_password'
+- **maas_postgres_password**: The password for the MAAS postgres user.\
+  Example: `'my_password'`
 
-- **maas_installation_type**: The intended type of MAAS installation. Possible values are: 'deb' or 'snap'
+- **maas_installation_type**: The intended type of MAAS installation.\
+  Possible values are: `'deb'` or `'snap'`
 
-- **maas_url**: The MAAS URL where MAAS will be accessed and which rack controllers should use for registering with region controllers. Example: 'http://proxy01.example.com:5240/MAAS'
+
+- **maas_url**: The MAAS URL where MAAS will be accessed and which rack controllers should use for registering with region controllers.\
+  Example: `'http://proxy01.example.com:5240/MAAS'`
 
 
 There are additional optional variables that can be passed to the playbooks:
 
 - [Admin credentials] [If setting up an admin user]
 
-  - **admin_username**: The username of the admin user
+  - **admin_username**: The username of the admin user\
     Default: `admin`
 
-  - **admin_password**: The password of the admin user
+  - **admin_password**: The password of the admin user\
     Default: `admin`
 
-  - **admin_email**: The email address of the admin user
+  - **admin_email**: The email address of the admin user\
     Default: `admin@email.com`
 
-  - **admin_id**: The launchpad id of the admin user
+  - **admin_id**: The launchpad id of the admin user\
     Default: `admin`
 
-- **maas_proxy_postgres_proxy_enabled**: Use postgres proxy uri
+- **maas_proxy_postgres_proxy_enabled**: Use postgres proxy uri\
   Default: `false`
 
-- **install_metrics**: Whether MAAS should install metrics
+- **install_metrics**: Whether MAAS should install metrics\
   Default: `false`
 
-- **enable_tls**: Whether MAAS should enable TLS
+- **enable_tls**: Whether MAAS should enable TLS\
   Default: `false` [Only valid for MAAS >= 3.2]
 
 - [MAAS Vault] [Only valid for MAAS >= 3.3]
 
-  - **vault_integration**: Whether MAAS Should use Vault for secret storage
+  - **vault_integration**: Whether MAAS Should use Vault for secret storage\
     Default: `false`
-  - **vault_url**: The URL of the MAAS Vault
+  - **vault_url**: The URL of the MAAS Vault\
     Default: undefined
-  - **vault_approle_id**: The approle id of the MAAS Vault
+  - **vault_approle_id**: The approle id of the MAAS Vault\
     Default: undefined
-  - **vault_wrapped_token**: The wrapped token for the MAAS Vault
+  - **vault_wrapped_token**: The wrapped token for the MAAS Vault\
     Default: undefined
-  - **vault_secrets_path**: The secrets path of the MAAS Vault
+  - **vault_secrets_path**: The secrets path of the MAAS Vault\
     Default: undefined
-  - **vault_secret_mount**: The secret mount of the MAAS Vault
+  - **vault_secret_mount**: The secret mount of the MAAS Vault\
     Default: undefined
 
-- **http_proxy**: The HTTP Proxy to use
+- **http_proxy**: The HTTP Proxy to use\
   Default: proxy not used
 
-- **https_proxy**: The HTTPS Proxy to use
+- **https_proxy**: The HTTPS Proxy to use\
   Default: proxy not used
 
 ### Deploy the MAAS stack

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ This playbook requires a user to set the following set of variables:
 
 There are additional optional variables that can be passed to the playbooks:
 
-- [Admin credentials] [If setting up an admin user]
+- ### Admin credentials (if setting up an admin user)
 
   - **admin_username**: The username of the admin user\
     Default: `admin`
@@ -129,9 +129,9 @@ There are additional optional variables that can be passed to the playbooks:
   Default: `false`
 
 - **enable_tls**: Whether MAAS should enable TLS\
-  Default: `false` [Only valid for MAAS >= 3.2]
+  Default: `false` (only valid for MAAS >= 3.2)
 
-- [MAAS Vault] [Only valid for MAAS >= 3.3]
+- ### MAAS Vault (only valid for MAAS >= 3.3)
 
   - **vault_integration**: Whether MAAS Should use Vault for secret storage\
     Default: `false`

--- a/README.md
+++ b/README.md
@@ -100,6 +100,53 @@ This playbook requires a user to set the following set of variables:
 
 - **maas_url**: The MAAS URL where MAAS will be accessed and which rack controllers should use for registering with region controllers. Example: 'http://proxy01.example.com:5240/MAAS'
 
+
+There are additional optional variables that can be passed to the playbooks:
+
+- [Admin credentials] [If setting up an admin user]
+
+  - **admin_username**: The username of the admin user
+    Default: `admin`
+
+  - **admin_password**: The password of the admin user
+    Default: `admin`
+
+  - **admin_email**: The email address of the admin user
+    Default: `admin@email.com`
+
+  - **admin_id**: The launchpad id of the admin user
+    Default: `admin`
+
+- **maas_proxy_postgres_proxy_enabled**: Use postgres proxy uri
+  Default: `false`
+
+- **install_metrics**: Whether MAAS should install metrics
+  Default: `false`
+
+- **enable_tls**: Whether MAAS should enable TLS
+  Default: `false` [Only valid for MAAS >= 3.2]
+
+- [MAAS Vault] [Only valid for MAAS >= 3.3]
+
+  - **vault_integration**: Whether MAAS Should use Vault for secret storage
+    Default: `false`
+  - **vault_url**: The URL of the MAAS Vault
+    Default: undefined
+  - **vault_approle_id**: The approle id of the MAAS Vault
+    Default: undefined
+  - **vault_wrapped_token**: The wrapped token for the MAAS Vault
+    Default: undefined
+  - **vault_secrets_path**: The secrets path of the MAAS Vault
+    Default: undefined
+  - **vault_secret_mount**: The secret mount of the MAAS Vault
+    Default: undefined
+
+- **http_proxy**: The HTTP Proxy to use
+  Default: proxy not used
+
+- **https_proxy**: The HTTPS Proxy to use
+  Default: proxy not used
+
 ### Deploy the MAAS stack
 
 ```

--- a/group_vars/all
+++ b/group_vars/all
@@ -51,6 +51,15 @@ maas_secret_file: "{{ '/var/snap/maas/common' if  maas_installation_type | lower
 
 maas_installmetric_file: "{{ '/var/snap/maas/common' if maas_installation_type | lower == 'snap' else '/var/lib/maas' }}/.ansible"
 
+# proxy support (default empty)
+http_proxy:
+https_proxy:
+# combined dict, don't touch
+proxy_env:
+  http_proxy: "{{ http_proxy }}"
+  https_proxy: "{{ https_proxy }}"
+
+
 # Operating system releases and the minimum version of MAAS they can run
 supported_distributions:
   Ubuntu:

--- a/group_vars/all
+++ b/group_vars/all
@@ -51,14 +51,7 @@ maas_secret_file: "{{ '/var/snap/maas/common' if  maas_installation_type | lower
 
 maas_installmetric_file: "{{ '/var/snap/maas/common' if maas_installation_type | lower == 'snap' else '/var/lib/maas' }}/.ansible"
 
-# proxy support (default empty)
-http_proxy:
-https_proxy:
-# combined dict, don't touch
 proxy_env:
-  http_proxy: "{{ http_proxy }}"
-  https_proxy: "{{ https_proxy }}"
-
 
 # Operating system releases and the minimum version of MAAS they can run
 supported_distributions:

--- a/roles/common/tasks/maas_supported_os.yaml
+++ b/roles/common/tasks/maas_supported_os.yaml
@@ -7,7 +7,7 @@
       - ansible_distribution in supported_distributions
 
 # fetch the highest release number in the dictionary that is equal or less than the host release number
-- name: "Fetch highest supported distro verison"
+- name: "Fetch highest supported distro version"
   ansible.builtin.set_fact:
     closest_distro_version: "{{ supported_distributions[ansible_distribution][supported_distributions[ansible_distribution].keys()
       | community.general.version_sort | reject('>', ansible_distribution_version | string) | last] }}"

--- a/site.yaml
+++ b/site.yaml
@@ -20,15 +20,15 @@
         that:
           - maas_version is regex('\d+\.\d+(\.\d+)?')
 
-    - name: "Define proxy environment if given"
+    - name: "Define proxy environment if proxies given"
       ansible.builtin.set_fact:
         proxy_env: "{{ proxy_env | combine({'http_proxy' : http_proxy | d(omit)}) |
           combine({'https_proxy' : https_proxy | d(omit)}) }}"
 
-    - name: "Debug https"
+    - name: "Show proxy environment if in use"
       ansible.builtin.debug:
         msg: "Playbooks using proxy settings: {{ proxy_env }}"
-      when: proxy_env
+      with_dict: "{{ proxy_env }}"
 
 - hosts: maas_postgres_primary
   roles:

--- a/site.yaml
+++ b/site.yaml
@@ -20,6 +20,10 @@
         that:
           - maas_version is regex('\d+\.\d+(\.\d+)?')
 
+    - name: "Debug"
+      ansible.builtin.debug:
+        msg: Playbooks using {{ proxy_env }} as a proxy
+
 - hosts: maas_postgres_primary
   roles:
     - role: maas_postgres_primary
@@ -28,6 +32,7 @@
   tags:
     - maas_postgres_primary
     - maas_postgres
+  environment: "{{ proxy_env }}"
 
 - hosts: maas_postgres_secondary
   roles:
@@ -37,6 +42,7 @@
   tags:
     - maas_postgres_secondary
     - maas_postgres
+  environment: "{{ proxy_env }}"
 
 # proxies are provisioned prior to rack controllers so the rack controller
 # will request to register to region controllers through the proxy
@@ -47,6 +53,7 @@
   gather_facts: true
   tags:
     - maas_proxy
+  environment: "{{ proxy_env }}"
 
 - hosts: maas_region_controller
   roles:
@@ -56,6 +63,7 @@
   tags:
     - maas_region_controller
     - maas_controller
+  environment: "{{ proxy_env }}"
 
 - hosts: maas_rack_controller
   roles:
@@ -65,3 +73,4 @@
   tags:
     - maas_rack_controller
     - maas_controller
+  environment: "{{ proxy_env }}"

--- a/site.yaml
+++ b/site.yaml
@@ -20,9 +20,15 @@
         that:
           - maas_version is regex('\d+\.\d+(\.\d+)?')
 
-    - name: "Debug"
+    - name: "Define proxy environment if given"
+      ansible.builtin.set_fact:
+        proxy_env: "{{ proxy_env | combine({'http_proxy' : http_proxy | d(omit)}) |
+          combine({'https_proxy' : https_proxy | d(omit)}) }}"
+
+    - name: "Debug https"
       ansible.builtin.debug:
-        msg: Playbooks using {{ proxy_env }} as a proxy
+        msg: "Playbooks using proxy settings: {{ proxy_env }}"
+      when: proxy_env
 
 - hosts: maas_postgres_primary
   roles:


### PR DESCRIPTION
systems-test:
- Introduce http_proxy and https_proxy environments, set through `http_proxy` and `https_proxy` at the `--extra_vars` stage