### PR TITLE
fix overriding of firewall ports in case of multiple roles

### DIFF
--- a/group_vars/maas_postgres/60-firewall
+++ b/group_vars/maas_postgres/60-firewall
@@ -1,6 +1,6 @@
 ---
-maas_open_tcp_ports: 
+maas_pg_tcp_ports: 
 - 5432
 - "{{ 9187 if o11y_enable else (false) }}"
 
-maas_open_udp_ports: []
+maas_pg_udp_ports: []

--- a/group_vars/maas_postgres_proxy/60-firewall
+++ b/group_vars/maas_postgres_proxy/60-firewall
@@ -1,6 +1,6 @@
 ---
-maas_open_tcp_ports:
+maas_pgproxy_tcp_ports:
 - 5432
 - "{{ 5051 if 'maas_postgres' in group_names else (false) }}"
 
-maas_open_udp_ports:
+maas_pgproxy_udp_ports:

--- a/group_vars/maas_proxy/60-firewall
+++ b/group_vars/maas_proxy/60-firewall
@@ -1,6 +1,6 @@
 ---
-maas_open_tcp_ports:
+maas_proxy_tcp_ports:
 - "{{ 5432 if 'maas_postgres' in group_names else (false) }}" 
 - "{{ maas_proxy_port }}"
 
-maas_open_udp_ports:
+maas_proxy_udp_ports:

--- a/group_vars/maas_rack_controller/60-firewall
+++ b/group_vars/maas_rack_controller/60-firewall
@@ -1,13 +1,13 @@
 ---
-maas_open_tcp_ports:
+maas_rack_tcp_ports:
 - 53		# dns
 - 514 		# rsyslog
 - 5248		# rack http port
-- 3218
+- 3128
 - 8000
 - "{{ maas_promtail_port if o11y_enable else (false) }}"
 
-maas_open_udp_ports:
+maas_rack_udp_ports:
 - 53 		# dns
 - 67:69 	# tftp, dhcp 
 - 123		# ntp

--- a/group_vars/maas_region_controller/60-firewall
+++ b/group_vars/maas_region_controller/60-firewall
@@ -1,5 +1,5 @@
 ---
-maas_open_tcp_ports: 
+maas_rack_tcp_ports: 
 - 53 			# dns
 - 514 			# rsyslog
 - 3128
@@ -13,7 +13,7 @@ maas_open_tcp_ports:
 - "{{ maas_proxy_postgres_port if 'maas_proxy' in group_names else (false) }}"
 - "{{ maas_promtail_port if o11y_enable else (false) }}"
 
-maas_open_udp_ports:
+maas_region_udp_ports:
 - 53 			# dns
 - 123 			# ntp
 - 514 			# rsyslog

--- a/roles/maas_firewall/tasks/setup_firewall_rules.yaml
+++ b/roles/maas_firewall/tasks/setup_firewall_rules.yaml
@@ -53,8 +53,12 @@
     protocol: tcp
     destination_port: "{{ item }}"
     jump: ACCEPT
-  with_items: '{{ maas_open_tcp_ports | select() }}'
-  when: maas_open_tcp_ports
+  with_items:
+    - '{{ maas_pg_tcp_ports | default([]) | select() }}'
+    - '{{ maas_pgproxy_tcp_ports | default([]) | select() }}'
+    - '{{ maas_proxy_tcp_ports | default([]) | select() }}'
+    - "{{ maas_rack_tcp_ports | default([]) | select() }}"
+    - "{{ maas_region_tcp_ports | default([]) | select() }}"
 
 - name: Open udp ports
   ansible.builtin.iptables:
@@ -62,8 +66,12 @@
     protocol: udp
     destination_port: "{{ item }}"
     jump: ACCEPT
-  with_items: "{{ maas_open_udp_ports }}"
-  when: maas_open_udp_ports
+  with_items:
+    - "{{ maas_pg_udp_ports | default([]) | select() }}"
+    - "{{ maas_pgproxy_udp_ports | default([]) | select() }}"
+    - "{{ maas_proxy_udp_ports | default([]) | select() }}"
+    - "{{ maas_rack_udp_ports | default([]) | select() }}"
+    - "{{ maas_region_udp_ports | default([]) | select() }}"
 
 - name: Set policy for INPUT chain to drop (otherwise)
   ansible.builtin.iptables:


### PR DESCRIPTION
A proposed solution for #125 
Renamed port variables for each role, and firewall setup uses those that are defined on a given host. 
Fixed a typo in one of the ports to be opened.