### PR TITLE
correct variable name of firewall ports

### DIFF
--- a/group_vars/maas_region_controller/60-firewall
+++ b/group_vars/maas_region_controller/60-firewall
@@ -1,5 +1,5 @@
 ---
-maas_rack_tcp_ports: 
+maas_region_tcp_ports:
 - 53 			# dns
 - 514 			# rsyslog
 - 3128


### PR DESCRIPTION
Fixed variable names for firewall ports in group_vars/maas_region_controller from `maas_rack_tcp_ports` to `maas_region_tcp_ports`.