### PR TITLE
[bugfix] Unconditionally use "maas" for refresh task

### DIFF
--- a/roles/maas_region_controller/tasks/update_maas.yaml
+++ b/roles/maas_region_controller/tasks/update_maas.yaml
@@ -23,7 +23,7 @@
   run_once: true
 
 - name: Refresh MAAS API
-  ansible.builtin.command: "{{ 'maas' if maas_installation_type | lower == 'snap' else 'maas-region' }} refresh"
+  ansible.builtin.command: "maas refresh"
   changed_when: false
 
 - name: Wait For MAAS To Create Secret File


### PR DESCRIPTION
The maas-region binary when installed via `deb` does not provide a "refresh" command on MAAS 3.3 on Ubuntu 22.04.

```
root@genesis:~# maas-region refresh 
Unknown command: 'refresh'
Type 'maas-region help' for usage.
```

It does however provide one on the `maas` binary:
```
root@genesis:~# maas refresh --help
usage: maas refresh [-h]

Refresh the API descriptions of all profiles.

options:
  -h, --help  show this help message and exit

This retrieves the latest version of the help information for each
profile.  Use it to update your command-line client's information after
an upgrade to the MAAS server.
```

I've made a patch to solve that, but it may need conditionals added based on MAAS versions (as maybe this wasn't true prior to MAAS 3.3)
