### PR TITLE
Disable proxy when checking postgres election

### DIFF
--- a/roles/maas_region_controller/tasks/install_maas.yaml
+++ b/roles/maas_region_controller/tasks/install_maas.yaml
@@ -54,6 +54,7 @@
     status_code:
       - 200
       - 204
+    use_proxy: false
   register: pg_healthcheck
   until: pg_healthcheck is not failed
   retries: 5


### PR DESCRIPTION
We may be failing to elect a new primary due to the global proxy settings, this should kick off a test of that theory