### PR TITLE
Update o11y config

### DIFF
--- a/group_vars/all/50-o11y
+++ b/group_vars/all/50-o11y
@@ -24,7 +24,7 @@ o11y_grafana_agent_dirs:
   - "{{ o11y_grafana_agent_wal_dir }}"
   - "{{ o11y_grafana_agent_pos_dir }}"
 
-grafana_agent_pkg: "https://github.com/grafana/agent/releases/download/v0.32.1/grafana-agent-linux-{{ ubuntu_arch }}.zip"
+grafana_agent_pkg: "https://github.com/grafana/agent/releases/download/v{{'0.37.4' if maas_version=3.5 else '0.32.1'}}/grafana-agent-linux-{{ ubuntu_arch }}.zip"
 
 o11y_postgres_exporter_dir: "/opt/postgres-exporter"
 pg_exp_pkg: "https://github.com/prometheus-community/postgres_exporter/releases/download/v0.11.1/postgres_exporter-0.11.1.linux-{{ ubuntu_arch }}.tar.gz"

--- a/group_vars/all/50-o11y
+++ b/group_vars/all/50-o11y
@@ -24,7 +24,7 @@ o11y_grafana_agent_dirs:
   - "{{ o11y_grafana_agent_wal_dir }}"
   - "{{ o11y_grafana_agent_pos_dir }}"
 
-grafana_agent_pkg: "https://github.com/grafana/agent/releases/download/v{{'0.37.4' if maas_version=3.5 else '0.32.1'}}/grafana-agent-linux-{{ ubuntu_arch }}.zip"
+grafana_agent_pkg: "https://github.com/grafana/agent/releases/download/v{{'0.37.4' if maas_version is version('3.5', '>=') else '0.32.1'}}/grafana-agent-linux-{{ ubuntu_arch }}.zip"
 
 o11y_postgres_exporter_dir: "/opt/postgres-exporter"
 pg_exp_pkg: "https://github.com/prometheus-community/postgres_exporter/releases/download/v0.11.1/postgres_exporter-0.11.1.linux-{{ ubuntu_arch }}.tar.gz"

--- a/roles/o11y_agent/tasks/main.yaml
+++ b/roles/o11y_agent/tasks/main.yaml
@@ -20,6 +20,10 @@
     name: unzip
     state: "present"
 
+- name: Print version of Grafana agent
+  ansible.builtin.debug:
+    msg: "{{ grafana_agent_pkg }}"
+
 - name: Download and unzip grafana agent
   ansible.builtin.unarchive:
     src: "{{ grafana_agent_pkg }}"
@@ -64,6 +68,6 @@
     src: "agent-{{ maas_installation_type }}.yaml.j2"
     dest: "{{ o11y_grafana_agent_dir }}/agent.yaml"
     mode: 0644
-  when: o11y_enable and maas_version is version("3.5",'==')
+  when: o11y_enable and maas_version is version("3.5",'>=')
   notify:
     - "Start grafana agent"

--- a/roles/o11y_agent/tasks/main.yaml
+++ b/roles/o11y_agent/tasks/main.yaml
@@ -55,6 +55,15 @@
     src: "grafana-agent.yaml.j2"
     dest: "{{ o11y_grafana_agent_dir }}/agent.yaml"
     mode: 0644
-  when: o11y_enable
+  when: o11y_enable and maas_version is version("3.5",'<')
+  notify:
+    - "Start grafana agent"
+
+- name: Agent configuration for MAAS 3.5
+  ansible.builtin.template:
+    src: "agent-{{ maas_installation_type }}.yaml.j2"
+    dest: "{{ o11y_grafana_agent_dir }}/agent.yaml"
+    mode: 0644
+  when: o11y_enable and maas_version is version("3.5",'==')
   notify:
     - "Start grafana agent"

--- a/roles/o11y_agent/tasks/main.yaml
+++ b/roles/o11y_agent/tasks/main.yaml
@@ -20,10 +20,6 @@
     name: unzip
     state: "present"
 
-- name: Print version of Grafana agent
-  ansible.builtin.debug:
-    msg: "{{ grafana_agent_pkg }}"
-
 - name: Download and unzip grafana agent
   ansible.builtin.unarchive:
     src: "{{ grafana_agent_pkg }}"

--- a/roles/o11y_agent/templates/agent-deb.yaml.j2
+++ b/roles/o11y_agent/templates/agent-deb.yaml.j2
@@ -1,0 +1,203 @@
+server:
+  log_level: info
+
+{% if o11y_prometheus_url|length > 0 %}
+metrics:
+  wal_directory: {{ o11y_grafana_agent_wal_dir }}
+  global:
+    scrape_interval: 30s
+    external_labels:
+      host: {{ ansible_hostname }}
+{% if group_names|intersect(['maas_region_controller', 'maas_rack_controller']) %}
+      maas_az: {{ maas_availability_zone | default('default') }}
+      maas_region: {{ 'True' if 'maas_region_controller' in group_names else 'False' }}
+      maas_rack: {{ 'True' if 'maas_rack_controller' in group_names else 'False' }}
+{% endif %}
+    remote_write:
+      - url: {{o11y_prometheus_url}}
+        name: prom-export
+  configs:
+{% if group_names|intersect(['maas_region_controller', 'maas_rack_controller']) %}
+    - name: 'maas'
+      scrape_configs:
+        - job_name: 'maas-metrics'
+          static_configs:
+            - targets: ['{{ ansible_hostname }}:5239']
+{% if 'maas_region_controller' in group_names %}
+        - job_name: 'maas-cluster-metrics'
+          static_configs:
+            - targets: ['{{ ansible_hostname }}:5240']
+          metrics_path: '/MAAS/metrics'
+{% endif %}
+{% endif %}
+{% if 'maas_postgres' in group_names %}
+    - name: 'postgres'
+      scrape_configs:
+        - job_name: 'database-metrics'
+          static_configs:
+            - targets: ['{{ ansible_hostname }}:9187']
+{% endif %}
+{% if 'maas_pacemaker' in group_names %}
+    - name: 'ha-cluster'
+      scrape_configs:
+        - job_name: 'cluster-metrics'
+          static_configs:
+            - targets: ['{{ ansible_hostname }}:9664']
+{% endif %}
+{% endif %}
+
+{% if o11y_loki_url|length > 0 %}
+logs:
+  positions_directory: {{ o11y_grafana_agent_pos_dir }}
+  configs:
+{% if group_names|intersect(['maas_region_controller', 'maas_rack_controller']) %}
+    - name: 'maas'
+      clients:
+        - url: {{ o11y_loki_url }}
+      scrape_configs:
+        - job_name: maas-audit
+          syslog:
+            listen_address: localhost:{{ maas_promtail_port }}
+            labels:
+              job: "maas-audit"
+              maas_az: {{ maas_availability_zone | default('default') }}
+              maas_region: {{ 'True' if 'maas_region_controller' in group_names else 'False' }}
+              maas_rack: {{ 'True' if 'maas_rack_controller' in group_names else 'False' }}
+              maas_module: "audit"
+          relabel_configs:
+            - source_labels: ['__syslog_message_hostname']
+              target_label: 'host'
+            - source_labels: ['__syslog_message_app_name']
+              target_label: 'maas_module'
+          pipeline_stages:
+            - regex:
+                expression: "^(?s) \\[(?P<severity>\\S+?)\\] ((?P<machine>\\S+): )?(?P<content>.*)$"
+            - output:
+                source: content
+            - labels:
+                severity:
+                machine:
+
+        - job_name: maas-console
+          journal:
+            matches: _SYSTEMD_UNIT=maas-regiond.service, _SYSTEMD_UNIT=maas-rackd.service
+            labels:
+              host: {{ ansible_hostname }}
+              maas_az: {{ maas_availability_zone | default('default') }}
+              maas_region: {{ 'True' if 'maas_region_controller' in group_names else 'False' }}
+              maas_rack: {{ 'True' if 'maas_rack_controller' in group_names else 'False' }}
+              job: "maas-console"
+
+{% if 'maas_rack_controller' in group_names %}
+        - job_name: maas-dhcpd
+          journal:
+            matches: _SYSTEMD_UNIT=dhcpd.service, _SYSTEMD_UNIT=dhcpd6.service
+            labels:
+              host: {{ ansible_hostname }}
+              maas_az: {{ maas_availability_zone | default('default') }}
+              maas_region: {{ 'True' if 'maas_region_controller' in group_names else 'False' }}
+              maas_rack: {{ 'True' if 'maas_rack_controller' in group_names else 'False' }}
+              job: "maas-dhcpd"
+{% endif %}
+
+        - job_name: maas-metadata
+          journal:
+            matches: _SYSTEMD_UNIT=maas-http.service
+            labels:
+              host: {{ ansible_hostname }}
+              maas_az: {{ maas_availability_zone | default('default') }}
+              maas_region: {{ 'True' if 'maas_region_controller' in group_names else 'False' }}
+              maas_rack: {{ 'True' if 'maas_rack_controller' in group_names else 'False' }}
+              job: "maas-metadata"
+
+        - job_name: maas-named
+          journal:
+            matches: _SYSTEMD_UNIT=named.service
+            labels:
+              host: {{ ansible_hostname }}
+              maas_az: {{ maas_availability_zone | default('default') }}
+              maas_region: {{ 'True' if 'maas_region_controller' in group_names else 'False' }}
+              maas_rack: {{ 'True' if 'maas_rack_controller' in group_names else 'False' }}
+              job: "maas-named"
+
+        - job_name: maas-ntpd
+          journal:
+            matches: _SYSTEMD_UNIT=chrony.service
+            labels:
+              host: {{ ansible_hostname }}
+              maas_az: {{ maas_availability_zone | default('default') }}
+              maas_region: {{ 'True' if 'maas_region_controller' in group_names else 'False' }}
+              maas_rack: {{ 'True' if 'maas_rack_controller' in group_names else 'False' }}
+              job: "maas-ntpd"
+
+        - job_name: maas-proxy
+          journal:
+            matches: _SYSTEMD_UNIT=maas-proxy.service
+            labels:
+              host: {{ ansible_hostname }}
+              maas_az: {{ maas_availability_zone | default('default') }}
+              maas_region: {{ 'True' if 'maas_region_controller' in group_names else 'False' }}
+              maas_rack: {{ 'True' if 'maas_rack_controller' in group_names else 'False' }}
+              job: "maas-proxy"
+
+        - job_name: maas-temporal
+          journal:
+            matches: _SYSTEMD_UNIT=maas-temporal.service
+            labels:
+              host: {{ ansible_hostname }}
+              maas_az: {{ maas_availability_zone | default('default') }}
+              maas_region: {{ 'True' if 'maas_region_controller' in group_names else 'False' }}
+              maas_rack: {{ 'True' if 'maas_rack_controller' in group_names else 'False' }}
+              job: "maas-temporal"
+
+        - job_name: maas-apiserver
+          journal:
+            matches: _SYSTEMD_UNIT=maas-apiserver.service
+            labels:
+              host: {{ ansible_hostname }}
+              maas_az: {{ maas_availability_zone | default('default') }}
+              maas_region: {{ 'True' if 'maas_region_controller' in group_names else 'False' }}
+              maas_rack: {{ 'True' if 'maas_rack_controller' in group_names else 'False' }}
+              job: "maas-apiserver"
+
+        - job_name: maas-agent
+          journal:
+            matches: _SYSTEMD_UNIT=maas-agent.service
+            labels:
+              host: {{ ansible_hostname }}
+              maas_az: {{ maas_availability_zone | default('default') }}
+              maas_region: {{ 'True' if 'maas_region_controller' in group_names else 'False' }}
+              maas_rack: {{ 'True' if 'maas_rack_controller' in group_names else 'False' }}
+              job: "maas-agent"
+{% endif %}
+{% if 'maas_postgres' in group_names %}
+    - name: 'postgres'
+      clients:
+        - url: {{ o11y_loki_url }}
+      scrape_configs:
+        - job_name: database-logs
+          static_configs:
+            - labels:
+                __path__: {{ maas_postgres_data_dir ~ 'log/postgresql.log' }}
+                host: {{ ansible_hostname }}
+                job: "database-logs"
+{% endif %}
+{% if 'maas_pacemaker' in group_names %}
+    - name: 'ha-cluster'
+      clients:
+        - url: {{ o11y_loki_url }}
+      scrape_configs:
+        - job_name: pacemaker-logs
+          static_configs:
+            - labels:
+                __path__: /var/log/pacemaker/pacemaker.log
+                host: {{ ansible_hostname }}
+                job: "pacemaker-logs"
+        - job_name: corosync-logs
+          static_configs:
+            - labels:
+                __path__: /var/log/corosync/corosync.log
+                host: {{ ansible_hostname }}
+                job: "corosync-logs"
+{% endif %}
+{% endif %}

--- a/roles/o11y_agent/templates/agent-snap.yaml.j2
+++ b/roles/o11y_agent/templates/agent-snap.yaml.j2
@@ -1,0 +1,203 @@
+server:
+  log_level: info
+
+{% if o11y_prometheus_url|length > 0 %}
+metrics:
+  wal_directory: {{ o11y_grafana_agent_wal_dir }}
+  global:
+    scrape_interval: 30s
+    external_labels:
+      host: {{ ansible_hostname }}
+{% if group_names|intersect(['maas_region_controller', 'maas_rack_controller']) %}
+      maas_az: {{ maas_availability_zone | default('default') }}
+      maas_region: {{ 'True' if 'maas_region_controller' in group_names else 'False' }}
+      maas_rack: {{ 'True' if 'maas_rack_controller' in group_names else 'False' }}
+{% endif %}
+    remote_write:
+      - url: {{o11y_prometheus_url}}
+        name: prom-export
+  configs:
+{% if group_names|intersect(['maas_region_controller', 'maas_rack_controller']) %}
+    - name: 'maas'
+      scrape_configs:
+        - job_name: 'maas-metrics'
+          static_configs:
+            - targets: ['{{ ansible_hostname }}:5239']
+{% if 'maas_region_controller' in group_names %}
+        - job_name: 'maas-cluster-metrics'
+          static_configs:
+            - targets: ['{{ ansible_hostname }}:5240']
+          metrics_path: '/MAAS/metrics'
+{% endif %}
+{% endif %}
+{% if 'maas_postgres' in group_names %}
+    - name: 'postgres'
+      scrape_configs:
+        - job_name: 'database-metrics'
+          static_configs:
+            - targets: ['{{ ansible_hostname }}:9187']
+{% endif %}
+{% if 'maas_pacemaker' in group_names %}
+    - name: 'ha-cluster'
+      scrape_configs:
+        - job_name: 'cluster-metrics'
+          static_configs:
+            - targets: ['{{ ansible_hostname }}:9664']
+{% endif %}
+{% endif %}
+
+{% if o11y_loki_url|length > 0 %}
+logs:
+  positions_directory: {{ o11y_grafana_agent_pos_dir }}
+  configs:
+{% if group_names|intersect(['maas_region_controller', 'maas_rack_controller']) %}
+    - name: 'maas'
+      clients:
+        - url: {{ o11y_loki_url }}
+      scrape_configs:
+        - job_name: maas-audit
+          syslog:
+            listen_address: localhost:{{ maas_promtail_port }}
+            labels:
+              job: "maas-audit"
+              maas_az: {{ maas_availability_zone | default('default') }}
+              maas_region: {{ 'True' if 'maas_region_controller' in group_names else 'False' }}
+              maas_rack: {{ 'True' if 'maas_rack_controller' in group_names else 'False' }}
+              maas_module: "audit"
+          relabel_configs:
+            - source_labels: ['__syslog_message_hostname']
+              target_label: 'host'
+            - source_labels: ['__syslog_message_app_name']
+              target_label: 'maas_module'
+          pipeline_stages:
+            - regex:
+                expression: "^(?s) \\[(?P<severity>\\S+?)\\] ((?P<machine>\\S+): )?(?P<content>.*)$"
+            - output:
+                source: content
+            - labels:
+                severity:
+                machine:
+
+        - job_name: maas-console
+          journal:
+            matches: SYSLOG_IDENTIFIER=maas-regiond, SYSLOG_IDENTIFIER=maas-rackd
+            labels:
+              host: {{ ansible_hostname }}
+              maas_az: {{ maas_availability_zone | default('default') }}
+              maas_region: {{ 'True' if 'maas_region_controller' in group_names else 'False' }}
+              maas_rack: {{ 'True' if 'maas_rack_controller' in group_names else 'False' }}
+              job: "maas-console"
+
+{% if 'maas_rack_controller' in group_names %}
+        - job_name: maas-dhcpd
+          journal:
+            matches: SYSLOG_IDENTIFIER=maas-dhcpd, SYSLOG_IDENTIFIER=maas-dhcpd6
+            labels:
+              host: {{ ansible_hostname }}
+              maas_az: {{ maas_availability_zone | default('default') }}
+              maas_region: {{ 'True' if 'maas_region_controller' in group_names else 'False' }}
+              maas_rack: {{ 'True' if 'maas_rack_controller' in group_names else 'False' }}
+              job: "maas-dhcpd"
+{% endif %}
+
+        - job_name: maas-metadata
+          journal:
+            matches: SYSLOG_IDENTIFIER=maas-http
+            labels:
+              host: {{ ansible_hostname }}
+              maas_az: {{ maas_availability_zone | default('default') }}
+              maas_region: {{ 'True' if 'maas_region_controller' in group_names else 'False' }}
+              maas_rack: {{ 'True' if 'maas_rack_controller' in group_names else 'False' }}
+              job: "maas-metadata"
+
+        - job_name: maas-named
+          journal:
+            matches: SYSLOG_IDENTIFIER=named
+            labels:
+              host: {{ ansible_hostname }}
+              maas_az: {{ maas_availability_zone | default('default') }}
+              maas_region: {{ 'True' if 'maas_region_controller' in group_names else 'False' }}
+              maas_rack: {{ 'True' if 'maas_rack_controller' in group_names else 'False' }}
+              job: "maas-named"
+
+        - job_name: maas-ntpd
+          journal:
+            matches: SYSLOG_IDENTIFIER=chronyd
+            labels:
+              host: {{ ansible_hostname }}
+              maas_az: {{ maas_availability_zone | default('default') }}
+              maas_region: {{ 'True' if 'maas_region_controller' in group_names else 'False' }}
+              maas_rack: {{ 'True' if 'maas_rack_controller' in group_names else 'False' }}
+              job: "maas-ntpd"
+
+        - job_name: maas-proxy
+          journal:
+            matches: SYSLOG_IDENTIFIER=maas-proxy
+            labels:
+              host: {{ ansible_hostname }}
+              maas_az: {{ maas_availability_zone | default('default') }}
+              maas_region: {{ 'True' if 'maas_region_controller' in group_names else 'False' }}
+              maas_rack: {{ 'True' if 'maas_rack_controller' in group_names else 'False' }}
+              job: "maas-proxy"
+
+        - job_name: maas-temporal
+          journal:
+            matches: SYSLOG_IDENTIFIER=maas-temporal
+            labels:
+              host: {{ ansible_hostname }}
+              maas_az: {{ maas_availability_zone | default('default') }}
+              maas_region: {{ 'True' if 'maas_region_controller' in group_names else 'False' }}
+              maas_rack: {{ 'True' if 'maas_rack_controller' in group_names else 'False' }}
+              job: "maas-temporal"
+
+        - job_name: maas-apiserver
+          journal:
+            matches: SYSLOG_IDENTIFIER=maas-apiserver
+            labels:
+              host: {{ ansible_hostname }}
+              maas_az: {{ maas_availability_zone | default('default') }}
+              maas_region: {{ 'True' if 'maas_region_controller' in group_names else 'False' }}
+              maas_rack: {{ 'True' if 'maas_rack_controller' in group_names else 'False' }}
+              job: "maas-apiserver"
+
+        - job_name: maas-agent
+          journal:
+            matches: SYSLOG_IDENTIFIER=maas-agent
+            labels:
+              host: {{ ansible_hostname }}
+              maas_az: {{ maas_availability_zone | default('default') }}
+              maas_region: {{ 'True' if 'maas_region_controller' in group_names else 'False' }}
+              maas_rack: {{ 'True' if 'maas_rack_controller' in group_names else 'False' }}
+              job: "maas-agent"
+{% endif %}
+{% if 'maas_postgres' in group_names %}
+    - name: 'postgres'
+      clients:
+        - url: {{ o11y_loki_url }}
+      scrape_configs:
+        - job_name: database-logs
+          static_configs:
+            - labels:
+                __path__: {{ maas_postgres_data_dir ~ 'log/postgresql.log' }}
+                host: {{ ansible_hostname }}
+                job: "database-logs"
+{% endif %}
+{% if 'maas_pacemaker' in group_names %}
+    - name: 'ha-cluster'
+      clients:
+        - url: {{ o11y_loki_url }}
+      scrape_configs:
+        - job_name: pacemaker-logs
+          static_configs:
+            - labels:
+                __path__: /var/log/pacemaker/pacemaker.log
+                host: {{ ansible_hostname }}
+                job: "pacemaker-logs"
+        - job_name: corosync-logs
+          static_configs:
+            - labels:
+                __path__: /var/log/corosync/corosync.log
+                host: {{ ansible_hostname }}
+                job: "corosync-logs"
+{% endif %}
+{% endif %}


### PR DESCRIPTION
Adds 2 new Grafana Agent configurations for snap and deb installs, including logic to apply the correct configuration depending on MAAS version and installation method chosen. It will also install a newer version of the Grafana Agent package for MAAS versions 3.5 and above

This will align Ansible playbooks o11y setup with the monitoring MAAS setup for upcoming MAAS 3.5